### PR TITLE
Stats optimization

### DIFF
--- a/benches/increment.rs
+++ b/benches/increment.rs
@@ -28,7 +28,7 @@ mod increment {
             });
         })
         .unwrap();
-        swym::print_stats();
+        swym::stats::print_stats();
     }
 
     #[bench]
@@ -49,6 +49,6 @@ mod increment {
             });
         })
         .unwrap();
-        swym::print_stats();
+        swym::stats::print_stats();
     }
 }

--- a/benches/set_one.rs
+++ b/benches/set_one.rs
@@ -31,7 +31,7 @@ mod set_one {
                 });
             })
             .unwrap();
-            swym::print_stats();
+            swym::stats::print_stats();
         }
     }
 
@@ -62,7 +62,7 @@ mod set_one {
                 });
             })
             .unwrap();
-            swym::print_stats();
+            swym::stats::print_stats();
         }
     }
 
@@ -87,7 +87,7 @@ mod set_one {
                 });
             })
             .unwrap();
-            swym::print_stats();
+            swym::stats::print_stats();
         }
     }
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -7,6 +7,9 @@ pub mod alloc;
 #[macro_use]
 pub mod fast_lazy_static;
 
+#[macro_use]
+pub mod phoenix_tls;
+
 pub mod epoch;
 pub mod frw_lock;
 pub mod gc;

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -15,7 +15,6 @@ pub mod frw_lock;
 pub mod gc;
 pub mod pointer;
 pub mod read_log;
-pub mod stats;
 pub mod tcell_erased;
 pub mod thread;
 pub mod usize_aligned;

--- a/src/internal/phoenix_tls.rs
+++ b/src/internal/phoenix_tls.rs
@@ -1,0 +1,218 @@
+use std::{cell::Cell, marker::PhantomData, mem::ManuallyDrop, ops::Deref, ptr::NonNull};
+
+pub struct FastTls<T> {
+    fast_ptr: Cell<Option<NonNull<T>>>,
+}
+
+impl<T> FastTls<T> {
+    #[inline]
+    pub const fn none() -> Self {
+        FastTls {
+            fast_ptr: Cell::new(None),
+        }
+    }
+
+    #[inline]
+    fn initialize(&self, value: &T) {
+        debug_assert!(
+            self.fast_ptr.get().is_none(),
+            "attempted to have two phoenix TLS vars at once"
+        );
+        self.fast_ptr.set(Some(value.into()))
+    }
+
+    #[inline]
+    fn get(&self) -> Option<NonNull<T>> {
+        self.fast_ptr.get()
+    }
+
+    #[inline]
+    fn clear(&self) {
+        debug_assert!(self.fast_ptr.get().is_some(), "double free on tls var");
+        self.fast_ptr.set(None)
+    }
+}
+
+pub trait PhoenixTlsApply: Sized {
+    type Item;
+
+    fn apply_fast_tls<F: FnOnce(&FastTls<Self::Item>) -> O, O>(f: F) -> O;
+    fn init() -> Phoenix<Self::Item, Self>;
+}
+
+#[derive(Debug)]
+#[repr(C)]
+struct PhoenixImpl<T> {
+    value:     T,
+    ref_count: Cell<usize>,
+}
+
+#[derive(Debug)]
+pub struct Phoenix<T: 'static, D: PhoenixTlsApply<Item = T>> {
+    raw:     NonNull<PhoenixImpl<T>>,
+    phantom: PhantomData<(PhoenixImpl<T>, D)>,
+}
+
+impl<T: 'static, D: PhoenixTlsApply<Item = T>> Clone for Phoenix<T, D> {
+    #[inline]
+    fn clone(&self) -> Self {
+        let count = self.as_ref().ref_count.get();
+        debug_assert!(count > 0, "attempt to clone a deallocated `Phoenix`");
+        self.as_ref().ref_count.set(count + 1);
+        Phoenix {
+            raw:     self.raw,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<T: 'static, D: PhoenixTlsApply<Item = T>> Drop for Phoenix<T, D> {
+    #[inline]
+    fn drop(&mut self) {
+        let count = self.as_ref().ref_count.get();
+        debug_assert!(count > 0, "double free on `Phoenix` attempted");
+        if likely!(count != 1) {
+            self.as_ref().ref_count.set(count - 1)
+        } else {
+            // this is safe as long as the reference counting logic is safe
+            unsafe {
+                dealloc::<_, D>(self.raw);
+            }
+
+            #[inline(never)]
+            #[cold]
+            unsafe fn dealloc<T: 'static, D: PhoenixTlsApply>(this_ptr: NonNull<PhoenixImpl<T>>) {
+                D::apply_fast_tls(|tls| tls.clear());
+                drop(Box::from_raw(this_ptr.as_ptr()));
+            }
+        }
+    }
+}
+
+impl<T: 'static, D: PhoenixTlsApply<Item = T>> Phoenix<T, D> {
+    #[inline]
+    pub fn new(value: T) -> Self {
+        let phoenix = Box::new(PhoenixImpl {
+            value,
+            ref_count: Cell::new(1),
+        });
+        let raw = Box::into_raw_non_null(phoenix);
+        D::apply_fast_tls(move |tls| {
+            let phoenix = Phoenix {
+                raw,
+                phantom: PhantomData,
+            };
+            tls.initialize(&phoenix);
+            phoenix
+        })
+    }
+
+    #[inline]
+    unsafe fn clone_raw(raw: NonNull<T>) -> Self {
+        let result = ManuallyDrop::new(Phoenix {
+            raw:     raw.cast::<PhoenixImpl<T>>(),
+            phantom: PhantomData,
+        });
+        (*result).clone()
+    }
+
+    #[inline]
+    fn get() -> Self {
+        D::apply_fast_tls(|tls| match tls.get() {
+            Some(phoenix_ptr) => unsafe { Self::clone_raw(phoenix_ptr) },
+            None => D::init(),
+        })
+    }
+
+    #[inline]
+    fn as_ref(&self) -> &PhoenixImpl<T> {
+        // this is safe as long as the reference counting logic is safe
+        unsafe { self.raw.as_ref() }
+    }
+}
+
+impl<T: 'static, D: PhoenixTlsApply<Item = T>> Deref for Phoenix<T, D> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        &self.as_ref().value
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct PhoenixKey<T: 'static, D: PhoenixTlsApply<Item = T>> {
+    phantom: PhantomData<(PhoenixImpl<T>, D)>,
+}
+
+impl<T: 'static, D: PhoenixTlsApply<Item = T>> PhoenixKey<T, D> {
+    #[inline]
+    pub const fn new() -> Self {
+        PhoenixKey {
+            phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn get(self) -> Phoenix<T, D> {
+        Phoenix::get()
+    }
+}
+
+macro_rules! phoenix_tls {
+    // empty (base case for the recursion)
+    () => {};
+
+    // process multiple declarations
+    ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = $init:expr; $($rest:tt)*) => (
+        __phoenix_tls_inner!($(#[$attr])* $vis $name, $t, $init);
+        phoenix_tls!($($rest)*);
+    );
+
+    // handle a single declaration
+    ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = $init:expr) => (
+        __phoenix_tls_inner!($(#[$attr])* $vis $name, $t, $init);
+    );
+}
+
+macro_rules! __phoenix_tls_inner {
+    (@key $(#[$attr:meta])* $vis:vis $name:ident, $t:ty, $init:expr) => {
+        {
+            impl $crate::internal::phoenix_tls::PhoenixTlsApply for $name {
+                type Item = $t;
+
+                #[inline]
+                fn apply_fast_tls<F: FnOnce(&$crate::internal::phoenix_tls::FastTls<Self::Item>) -> O, O>(f: F) -> O {
+                    #[thread_local]
+                    static TLS: $crate::internal::phoenix_tls::FastTls<$t> = $crate::internal::phoenix_tls::FastTls::none();
+
+                    f(&TLS)
+                }
+
+                #[inline(never)]
+                #[cold]
+                fn init() -> $crate::internal::phoenix_tls::Phoenix<Self::Item, Self> {
+                    thread_local!{
+                        static TLS: $crate::internal::phoenix_tls::Phoenix<$t, $name>
+                            = $crate::internal::phoenix_tls::Phoenix::new($init);
+                    }
+                    TLS.try_with(|tls| {
+                        tls.clone()
+                    }).unwrap_or_else(|_| {
+                        $crate::internal::phoenix_tls::Phoenix::new($init)
+                    })
+                }
+            }
+
+            $crate::internal::phoenix_tls::PhoenixKey::new()
+        }
+    };
+    ($(#[$attr:meta])* $vis:vis $name:ident, $t:ty, $init:expr) => {
+        #[allow(non_camel_case_types)]
+        enum $name {}
+        $(#[$attr])* $vis const $name: $crate::internal::phoenix_tls::PhoenixKey<
+            $t,
+            $name,
+        > = __phoenix_tls_inner!(@key $(#[$attr])* $vis $name, $t, $init);
+    }
+}

--- a/src/internal/pointer.rs
+++ b/src/internal/pointer.rs
@@ -309,6 +309,7 @@ impl<T> PtrExt for *mut T {
 
     #[inline]
     unsafe fn add(self, value: usize) -> Self {
+        #[cfg(not(miri))]
         assume!(
             (self.as_ptr() as usize).checked_add(value).is_some(),
             "overflow on `PtrExt::add`"
@@ -318,6 +319,7 @@ impl<T> PtrExt for *mut T {
 
     #[inline]
     unsafe fn sub(self, value: usize) -> Self {
+        #[cfg(not(miri))]
         assume!(
             (self.as_ptr() as usize).checked_sub(value).is_some(),
             "overflow on `PtrExt::sub`"

--- a/src/internal/read_log.rs
+++ b/src/internal/read_log.rs
@@ -3,7 +3,10 @@
 //! The only meaningful operations are filtering out writes from the ReadLog (see thread.rs), and
 //! checking that the reads are still valid (validate_reads).
 
-use crate::internal::{alloc::FVec, epoch::QuiesceEpoch, stats, tcell_erased::TCellErased};
+use crate::{
+    internal::{alloc::FVec, epoch::QuiesceEpoch, tcell_erased::TCellErased},
+    stats,
+};
 use std::num::NonZeroUsize;
 use swym_htm::HardwareTx;
 

--- a/src/internal/stats.rs
+++ b/src/internal/stats.rs
@@ -128,6 +128,7 @@ stats! {
     bloom_check:                      Event,
     bloom_failure:                    Event,
     bloom_success_slow:               Event,
+    read_after_write:                 Event,
     write_after_write:                Event,
     write_after_logged_read:          Size,
 }
@@ -141,7 +142,7 @@ impl Stats {
         let successful_transactions =
             self.read_transaction_retries.count + self.write_transaction_eager_retries.count;
 
-        let failures = self
+        let retries = self
             .read_transaction_retries
             .min_max_total
             .unwrap_or_default()
@@ -157,32 +158,24 @@ impl Stats {
                 .unwrap_or_default()
                 .total;
         println!(
-            "{:>12}: {:>12} {:>9} {:.2}% {:>9} {:.2}%",
+            "{:>12}: {:>12} {:>9}: {:.4} {:>13}: {:.4}",
             "transactions",
             successful_transactions,
-            "fail avg",
-            failures as f64 / successful_transactions as f64 * 100.0,
-            "htm fails avg",
-            self.htm_retries.min_max_total.unwrap_or_default().total as f64
-                / successful_transactions as f64
-                * 100.0
-        );
-        println!(
-            "{:>12}: {:>12.6}",
+            "retry avg",
+            retries as f64 / successful_transactions as f64,
             "htm retry avg",
             self.htm_retries.min_max_total.unwrap_or_default().total as f64
-                / self.htm_retries.count as f64
+                / successful_transactions as f64
         );
         println!(
-            "{:>12}: {:>12} {:>9} {:.2}% {:>9} {:.2}%",
+            "{:>12}: {:>12} {:>9}: {:.4} {:>13}: {:.4}",
             "bloom checks",
             self.bloom_check.count,
             "fail rate",
-            self.bloom_failure.count as f64 / self.bloom_check.count as f64 * 100.0,
+            self.bloom_failure.count as f64 / self.bloom_check.count as f64,
             "slow rate",
             (self.bloom_success_slow.count + self.bloom_failure.count) as f64
                 / self.bloom_check.count as f64
-                * 100.0
         );
     }
 }

--- a/src/internal/stats.rs
+++ b/src/internal/stats.rs
@@ -53,7 +53,7 @@ macro_rules! stats_func {
         #[inline]
         pub fn $name() {
             if cfg!(feature = "stats") {
-                THREAD_STAT.with(|ts| (ts.borrow_mut().0).$name.happened())
+                (THREAD_STAT.get().borrow_mut().0).$name.happened()
             }
         }
     };
@@ -62,7 +62,7 @@ macro_rules! stats_func {
         pub fn $name(size: usize) {
             if cfg!(feature = "stats") {
                 let size = size as u64;
-                THREAD_STAT.with(move |ts| (ts.borrow_mut().0).$name.record(size))
+                (THREAD_STAT.get().borrow_mut().0).$name.record(size)
             }
         }
     };
@@ -135,7 +135,7 @@ impl Drop for ThreadStats {
     }
 }
 
-thread_local! {
+phoenix_tls! {
     static THREAD_STAT: RefCell<ThreadStats> = {
         drop(GLOBAL.get()); // initialize global now, else we may get panics on drop because
                             // lazy_static uses thread_locals to initialize it.

--- a/src/internal/thread.rs
+++ b/src/internal/thread.rs
@@ -3,13 +3,16 @@ use crate::{
         epoch::{QuiesceEpoch, EPOCH_CLOCK},
         gc::{GlobalSynchList, OwnedSynch, ThreadGarbage},
         read_log::ReadLog,
-        stats,
         write_log::WriteLog,
     },
     read::ReadTx,
     rw::RwTx,
     tx::Error,
 };
+
+// TODO: rustfmt bug causes other imports to be deleted.
+use crate::stats;
+
 use std::{
     cell::{Cell, UnsafeCell},
     fmt::{self, Debug, Formatter},

--- a/src/internal/thread.rs
+++ b/src/internal/thread.rs
@@ -507,7 +507,9 @@ impl<'tx, 'tcell> PinRw<'tx, 'tcell> {
                     stats::htm_retries(retry_count);
                     return success;
                 }
-                Err(HtxRetry::SoftwareFallback) => {}
+                Err(HtxRetry::SoftwareFallback) => {
+                    stats::htm_retries(retry_count);
+                }
                 Err(HtxRetry::FullRetry) => {
                     stats::htm_retries(retry_count);
                     return false;

--- a/src/internal/write_log.rs
+++ b/src/internal/write_log.rs
@@ -224,7 +224,7 @@ impl<'tcell> WriteLog<'tcell> {
         if result.is_some() {
             stats::bloom_success_slow()
         } else {
-            stats::bloom_failure()
+            stats::bloom_collision()
         }
         result
     }
@@ -261,7 +261,7 @@ impl<'tcell> WriteLog<'tcell> {
                 Entry::new_occupied(unsafe { mem::transmute(entry) }, hash)
             }
             None => {
-                stats::bloom_failure();
+                stats::bloom_collision();
                 Entry::new_hash(self, hash)
             }
         }

--- a/src/internal/write_log.rs
+++ b/src/internal/write_log.rs
@@ -1,11 +1,14 @@
-use crate::internal::{
-    alloc::{dyn_vec::DynElemMut, DynVec},
-    epoch::QuiesceEpoch,
-    pointer::PtrExt,
+use crate::{
+    internal::{
+        alloc::{dyn_vec::DynElemMut, DynVec},
+        epoch::QuiesceEpoch,
+        pointer::PtrExt,
+        tcell_erased::TCellErased,
+        usize_aligned::ForcedUsizeAligned,
+    },
     stats,
-    tcell_erased::TCellErased,
-    usize_aligned::ForcedUsizeAligned,
 };
+
 use std::{
     mem::{self, ManuallyDrop},
     num::NonZeroUsize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@
 
 #![feature(align_offset)]
 #![feature(allocator_api)]
+#![feature(box_into_raw_non_null)]
 #![feature(cfg_target_thread_local)]
 #![feature(const_fn)]
 #![feature(core_intrinsics)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,12 +95,12 @@ mod internal;
 
 mod read;
 mod rw;
+pub mod stats;
 pub mod tcell;
 pub mod thread_key;
 pub mod tptr;
 pub mod tx;
 
-pub use internal::stats::print_stats;
 pub use read::ReadTx;
 pub use rw::RwTx;
 #[doc(inline)]

--- a/src/rw.rs
+++ b/src/rw.rs
@@ -10,6 +10,7 @@
 use crate::{
     internal::{
         alloc::dyn_vec::DynElemMut,
+        stats,
         tcell_erased::TCellErased,
         thread::{PinMutRef, PinRw},
         write_log::{bloom_hash, Contained, Entry, WriteEntryImpl},
@@ -73,6 +74,7 @@ impl<'tx, 'tcell> RwTxImpl<'tx, 'tcell> {
                     }
                 }
                 Some(entry) => {
+                    stats::read_after_write();
                     let value = Ref::new(entry.read::<T>());
                     if likely!(self.rw_valid(&tcell.erased)) {
                         return Ok(value);
@@ -115,6 +117,7 @@ impl<'tx, 'tcell> RwTxImpl<'tx, 'tcell> {
                     }
                 }
                 Some(entry) => {
+                    stats::read_after_write();
                     let value = Ref::new(entry.read::<T>());
                     if likely!(self.rw_valid(&tcell.erased)) {
                         return Ok(value);

--- a/src/rw.rs
+++ b/src/rw.rs
@@ -10,11 +10,11 @@
 use crate::{
     internal::{
         alloc::dyn_vec::DynElemMut,
-        stats,
         tcell_erased::TCellErased,
         thread::{PinMutRef, PinRw},
         write_log::{bloom_hash, Contained, Entry, WriteEntryImpl},
     },
+    stats,
     tcell::{Ref, TCell},
     tx::{self, Error, Ordering, SetError, Write, _TValue},
 };

--- a/swym-rbtree/benches/insert.rs
+++ b/swym-rbtree/benches/insert.rs
@@ -40,5 +40,5 @@ fn insert_remove(b: &mut Bencher) {
         });
     })
     .unwrap();
-    swym::print_stats();
+    swym::stats::print_stats();
 }

--- a/swym-rbtree/benches/rbtree.rs
+++ b/swym-rbtree/benches/rbtree.rs
@@ -48,7 +48,7 @@ mod rbtree {
                     .unwrap();
                     std::mem::forget(_tree);
                 });
-                swym::print_stats();
+                swym::stats::print_stats();
             }
         };
     }
@@ -96,7 +96,7 @@ mod rbtree {
                     })
                     .unwrap();
                 });
-                swym::print_stats();
+                swym::stats::print_stats();
             }
         };
     }
@@ -150,7 +150,7 @@ mod rbtree {
                     })
                     .unwrap();
                 });
-                swym::print_stats();
+                swym::stats::print_stats();
             }
         };
     }
@@ -204,7 +204,7 @@ mod rbtree {
                     })
                     .unwrap();
                 });
-                swym::print_stats();
+                swym::stats::print_stats();
             }
         };
     }

--- a/swym-rbtree/tests/count.rs
+++ b/swym-rbtree/tests/count.rs
@@ -44,7 +44,7 @@ fn count() {
     })
     .unwrap();
     assert_eq!(COUNT.load(Relaxed), 0);
-    swym::print_stats();
+    swym::stats::print_stats();
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn count_rev() {
     })
     .unwrap();
     assert_eq!(COUNT.load(Relaxed), 0);
-    swym::print_stats();
+    swym::stats::print_stats();
 }
 
 #[test]
@@ -94,7 +94,7 @@ fn count_remove() {
     })
     .unwrap();
     assert_eq!(COUNT.load(Relaxed), 0);
-    swym::print_stats();
+    swym::stats::print_stats();
 }
 
 #[test]
@@ -121,5 +121,5 @@ fn count_remove_rev() {
     })
     .unwrap();
     assert_eq!(COUNT.load(Relaxed), 0);
-    swym::print_stats();
+    swym::stats::print_stats();
 }

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -11,8 +11,8 @@ mod tls {
                 let tcell = TCell::new("foobar longish string".to_owned());
                 thread_key::get()
                     .try_rw(|tx| {
-                        let s = tcell.borrow(tx, Ordering::default())?;
-                        tcell.set(tx, "more ".to_owned() + &s)?;
+                        let s = "more ".to_owned() + &tcell.borrow(tx, Ordering::default())?;
+                        tcell.set(tx, s)?;
                         Ok(())
                     })
                     .unwrap();

--- a/x.py
+++ b/x.py
@@ -5,7 +5,7 @@ import sys
 
 if sys.argv[1] == 'test':
     prefix = "RUST_TEST_THREADS=1"
-    suffix = '--features debug-alloc,stats'
+    suffix = '--features debug-alloc,stats,rtm'
 elif sys.argv[1] == 'bench':
     prefix = 'RUSTFLAGS="$RUSTFLAGS -Ctarget-cpu=native -Ctarget-feature=+rtm"'
     suffix = ''

--- a/x.py
+++ b/x.py
@@ -4,8 +4,8 @@ import os
 import sys
 
 if sys.argv[1] == 'test':
-    prefix = "RUST_TEST_THREADS=1"
-    suffix = '--features debug-alloc,stats,rtm'
+    prefix = 'RUST_TEST_THREADS=1 RUSTFLAGS="$RUSTFLAGS -Ctarget-feature=+rtm"'
+    suffix = '--features debug-alloc,stats'
 elif sys.argv[1] == 'bench':
     prefix = 'RUSTFLAGS="$RUSTFLAGS -Ctarget-cpu=native -Ctarget-feature=+rtm"'
     suffix = ''


### PR DESCRIPTION
Recording stats has less of an impact on performance than it previously did. This greatly improves the usefulness of `stats` for high contention workloads.

`phoenix_tls` should be modified slightly to support `ThreadKey` as well. Some sort of subscribe/unsubscribe mechanism is needed.