### PR TITLE
major change: parking retry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,8 @@ matrix:
     name: "rbtree"
     script: ./ci/rbtree.sh
   - rust: nightly
-    name: "rustfmt"
-    script: |
-      if rustup component add rustfmt-preview ; then
-          cargo fmt --all -- --check
-      fi
+    name: "rustfmt/rustdoc"
+    script: ./ci/meta.sh
 
   # macos 64bit (no rtm)
   - os: osx

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,9 @@ stats = []
 [dependencies]
 cfg-if = "0.1.7"
 crossbeam-utils = "0.6.5"
-fxhash = "0.2.*"
-lazy_static = "1.3.*"
-lock_api = "0.1.5"
-parking_lot = "0.7.1"
+lazy_static = "1.3.0"
+lock_api = "0.2.0"
+parking_lot = "0.8.0"
 parking_lot_core = "0.5.0"
 swym-htm = { path = "./swym-htm", version = "0.1.0" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ stats = []
 [dependencies]
 cfg-if = "0.1.7"
 crossbeam-utils = "0.6.5"
+fxhash = "0.2.*"
 lazy_static = "1.3.*"
 lock_api = "0.1.5"
 parking_lot = "0.7.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,10 @@ stats = []
 [dependencies]
 cfg-if = "0.1.7"
 crossbeam-utils = "0.6.5"
-lazy_static = "1.3.0"
+lazy_static = "1.3.*"
 lock_api = "0.1.5"
 parking_lot = "0.7.1"
+parking_lot_core = "0.5.0"
 swym-htm = { path = "./swym-htm", version = "0.1.0" }
 
 [dev-dependencies]

--- a/ci/meta.sh
+++ b/ci/meta.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -ex
+
+if rustup component add rustfmt-preview ; then
+    cargo fmt --all -- --check
+fi
+
+export RUSTFLAGS="-D warnings"
+
+cargo doc --all

--- a/ci/swym.sh
+++ b/ci/swym.sh
@@ -42,6 +42,10 @@ time cargo run \
     --features stats,$RTM \
     --example dining_philosophers
 
+time cargo run \
+    --features stats,$RTM \
+    --example tlock
+
 # benchmarks
 if [[ -z $RTM ]]; then
     ./x.py bench --features nightly

--- a/examples/dining_philosophers.rs
+++ b/examples/dining_philosophers.rs
@@ -53,7 +53,7 @@ fn main() {
                         }
                     });
 
-                    println!("om nom nom {}", i);
+                    // println!("om nom nom {}", i);
                     std::thread::sleep(std::time::Duration::from_micros(EAT_TIME_MICROS));
 
                     thread_key.rw(|tx| {

--- a/examples/dining_philosophers.rs
+++ b/examples/dining_philosophers.rs
@@ -39,7 +39,7 @@ fn main() {
             scope.spawn(move |_| {
                 let mut retry_count = 0;
                 let thread_key = thread_key::get();
-                for i in 0..FOOD_ITERATIONS {
+                for _i in 0..FOOD_ITERATIONS {
                     thread_key.rw(|tx| {
                         if left_fork.in_use.get(tx, Ordering::default())?
                             || right_fork.in_use.get(tx, Ordering::default())?
@@ -53,7 +53,7 @@ fn main() {
                         }
                     });
 
-                    // println!("om nom nom {}", i);
+                    // println!("om nom nom {}", _i);
                     std::thread::sleep(std::time::Duration::from_micros(EAT_TIME_MICROS));
 
                     thread_key.rw(|tx| {

--- a/examples/dining_philosophers.rs
+++ b/examples/dining_philosophers.rs
@@ -6,7 +6,8 @@ use swym::{
 };
 
 const NUM_PHILOSOPHERS: usize = 5;
-const FOOD_ITERATIONS: usize = 1_000_000;
+const FOOD_ITERATIONS: usize = 100_000;
+const EAT_TIME_MICROS: u64 = 1;
 
 struct Fork {
     in_use: TCell<bool>,
@@ -33,10 +34,10 @@ fn main() {
             let right_fork = &forks[(i + 1) % NUM_PHILOSOPHERS];
             scope.spawn(move |_| {
                 let thread_key = thread_key::get();
-                for _ in 0..FOOD_ITERATIONS {
+                for i in 0..FOOD_ITERATIONS {
                     thread_key.rw(|tx| {
-                        if left_fork.in_use.get(tx, Ordering::Read)?
-                            || right_fork.in_use.get(tx, Ordering::Read)?
+                        if left_fork.in_use.get(tx, Ordering::default())?
+                            || right_fork.in_use.get(tx, Ordering::default())?
                         {
                             Err(Error::RETRY)
                         } else {
@@ -46,7 +47,8 @@ fn main() {
                         }
                     });
 
-                    // om nom nom
+                    println!("om nom nom {}", i);
+                    std::thread::sleep(std::time::Duration::from_micros(EAT_TIME_MICROS));
 
                     thread_key.rw(|tx| {
                         left_fork.in_use.set(tx, false)?;

--- a/examples/dining_philosophers.rs
+++ b/examples/dining_philosophers.rs
@@ -1,4 +1,5 @@
 use crossbeam_utils::thread;
+use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 use swym::{
     tcell::TCell,
     thread_key,
@@ -23,6 +24,9 @@ impl Fork {
 
 /// a bit contrived
 fn main() {
+    let total_retry_count = AtomicUsize::new(0);
+    let total_retry_count = &total_retry_count;
+
     let mut forks = Vec::new();
     for _ in 0..NUM_PHILOSOPHERS {
         forks.push(Fork::new());
@@ -33,12 +37,14 @@ fn main() {
             let left_fork = &forks[i];
             let right_fork = &forks[(i + 1) % NUM_PHILOSOPHERS];
             scope.spawn(move |_| {
+                let mut retry_count = 0;
                 let thread_key = thread_key::get();
                 for i in 0..FOOD_ITERATIONS {
                     thread_key.rw(|tx| {
                         if left_fork.in_use.get(tx, Ordering::default())?
                             || right_fork.in_use.get(tx, Ordering::default())?
                         {
+                            retry_count += 1;
                             Err(Error::RETRY)
                         } else {
                             left_fork.in_use.set(tx, true)?;
@@ -56,8 +62,10 @@ fn main() {
                         Ok(())
                     })
                 }
+                total_retry_count.fetch_add(retry_count, Relaxed);
             });
         }
     })
     .unwrap();
+    println!("Total Retry Count: {:?}", total_retry_count.load(Relaxed));
 }

--- a/examples/dining_philosophers.rs
+++ b/examples/dining_philosophers.rs
@@ -45,7 +45,7 @@ fn main() {
                             || right_fork.in_use.get(tx, Ordering::default())?
                         {
                             retry_count += 1;
-                            Err(Status::RETRY)
+                            Err(Status::AWAIT_RETRY)
                         } else {
                             left_fork.in_use.set(tx, true)?;
                             right_fork.in_use.set(tx, true)?;

--- a/examples/dining_philosophers.rs
+++ b/examples/dining_philosophers.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 use swym::{
     tcell::TCell,
     thread_key,
-    tx::{Error, Ordering},
+    tx::{Ordering, Status},
 };
 
 const NUM_PHILOSOPHERS: usize = 5;
@@ -45,7 +45,7 @@ fn main() {
                             || right_fork.in_use.get(tx, Ordering::default())?
                         {
                             retry_count += 1;
-                            Err(Error::RETRY)
+                            Err(Status::RETRY)
                         } else {
                             left_fork.in_use.set(tx, true)?;
                             right_fork.in_use.set(tx, true)?;

--- a/examples/stack.rs
+++ b/examples/stack.rs
@@ -164,9 +164,10 @@ fn main() {
     t0.join().unwrap();
     t1.join().unwrap();
     let elems = thread_key::get().read(|tx| {
-        LIST.iter(tx)?
+        Ok(LIST
+            .iter(tx)?
             .map(|ok| ok.map(|ok| ok.0))
-            .collect::<Result<Vec<_>, _>>()
+            .collect::<Result<Vec<_>, _>>()?)
     });
     assert!(elems.is_empty());
     drop(elems);

--- a/examples/tlock.rs
+++ b/examples/tlock.rs
@@ -23,7 +23,7 @@ unsafe impl RawMutex for RawTLock {
                 // The `Ordering` - `Default::default` - used above puts `held` in our read set.
                 // `swym` will watch for modifications to `held`, and wake this thread up when it is
                 // next modified.
-                return Err(Status::RETRY);
+                return Err(Status::AWAIT_RETRY);
             } else {
                 // The lock is not held, so grab it!
                 self.held.set(tx, true)?;

--- a/examples/tlock.rs
+++ b/examples/tlock.rs
@@ -1,0 +1,83 @@
+use crossbeam_utils::thread;
+use lock_api::{GuardSend, RawMutex};
+use swym::{tcell::TCell, thread_key, tx::Status};
+
+/// A proof of concept lock built on top of STM. This is probably an anti-pattern, but educational
+/// nonetheless.
+struct RawTLock {
+    held: TCell<bool>,
+}
+
+unsafe impl RawMutex for RawTLock {
+    const INIT: Self = RawTLock {
+        held: TCell::new(false),
+    };
+    type GuardMarker = GuardSend;
+
+    /// Acquires this mutex, blocking the current thread until it is able to do so.
+    fn lock(&self) {
+        thread_key::get().rw(|tx| {
+            if self.held.get(tx, Default::default())? {
+                // Sleep, until the lock is released
+                //
+                // The `Ordering` - `Default::default` - used above puts `held` in our read set.
+                // `swym` will watch for modifications to `held`, and wake this thread up when it is
+                // next modified.
+                return Err(Status::RETRY);
+            } else {
+                // The lock is not held, so grab it!
+                self.held.set(tx, true)?;
+            }
+            Ok(())
+        })
+    }
+
+    /// Attempts to acquire this mutex without blocking.
+    fn try_lock(&self) -> bool {
+        thread_key::get().rw(|tx| {
+            Ok(if self.held.get(tx, Default::default())? {
+                // The lock is held, return false
+                false
+            } else {
+                // The lock is not held, grab it
+                self.held.set(tx, true)?;
+                true
+            })
+        })
+    }
+
+    /// Unlocks this mutex.
+    fn unlock(&self) {
+        thread_key::get().rw(|tx| Ok(self.held.set(tx, false)?))
+    }
+}
+
+type TLock<T> = lock_api::Mutex<RawTLock, T>;
+
+fn main() {
+    let string = TLock::new("some string".to_owned());
+
+    // If you definitely want a lock, `parking_lot`'s are faster.
+    // let string = parking_lot::Mutex::new("some string".to_owned());
+
+    // `std::sync::Mutex` tends on OSX tends to perform worse than `TLock`
+    // let string = std::sync::Mutex::new("some string".to_owned());
+
+    let string = &string;
+
+    // Uncomment the line below to see deadlock (and 0% cpu usage showing all threads parked).
+    // let _deadlock = string.lock();
+    thread::scope(|s| {
+        for i in 0..8 {
+            s.spawn(move |_| {
+                for _ in 0..1000_000 {
+                    let mut guard = string.lock();
+                    *guard = format!("hello there from thread {}", i);
+                }
+            });
+        }
+    })
+    .unwrap();
+
+    println!("last thread's message:\n    '{}'", *string.lock())
+}

--- a/examples/tlock.rs
+++ b/examples/tlock.rs
@@ -70,7 +70,7 @@ fn main() {
     thread::scope(|s| {
         for i in 0..8 {
             s.spawn(move |_| {
-                for _ in 0..1000_000 {
+                for _ in 0..1_000_000 {
                     let mut guard = string.lock();
                     *guard = format!("hello there from thread {}", i);
                 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -9,6 +9,7 @@ pub mod phoenix_tls;
 
 pub mod epoch;
 pub mod gc;
+pub mod parking;
 pub mod read_log;
 pub mod tcell_erased;
 pub mod thread;

--- a/src/internal/epoch.rs
+++ b/src/internal/epoch.rs
@@ -327,7 +327,7 @@ impl EpochLock {
 
     /// Attempts to clear the unpark bit.
     #[inline]
-    pub fn tag_parked(&self, max_expected: QuiesceEpoch) -> bool {
+    pub fn try_clear_unpark_bit(&self, max_expected: QuiesceEpoch) -> bool {
         debug_assert!(
             max_expected.is_active(),
             "invalid max_expected epoch sent to `EpochLock::try_lock`"
@@ -352,7 +352,7 @@ impl EpochLock {
 
     /// Set the unpark bit.
     #[inline]
-    pub fn untag_parked(&self) {
+    pub fn set_unpark_bit(&self) {
         drop(self.0.fetch_or(UNPARK_BIT, Relaxed));
     }
 }

--- a/src/internal/parking.rs
+++ b/src/internal/parking.rs
@@ -44,8 +44,8 @@ unsafe fn should_unpark(ParkToken(token): ParkToken) -> bool {
 pub fn park<'tx, 'tcell>(mut pin: PinRw<'tx, 'tcell>, backoff: &Backoff) {
     debug_assert!(
         parkable(pin.reborrow()),
-        "`RETRY` on a transaction that has an empty read set causes the thread to sleep forever \
-         in release"
+        "`AWAIT_RETRY` on a transaction that has an empty read set causes the thread to sleep \
+         forever in release"
     );
 
     let parked_pin = pin.parked();
@@ -74,6 +74,7 @@ pub fn park<'tx, 'tcell>(mut pin: PinRw<'tx, 'tcell>, backoff: &Backoff) {
             }
         }
     }
+    drop(parked_pin);
 }
 
 #[inline(never)]

--- a/src/internal/parking.rs
+++ b/src/internal/parking.rs
@@ -1,0 +1,53 @@
+use crate::internal::{
+    epoch::EPOCH_CLOCK,
+    thread::{PinMutRef, PinRef},
+};
+use parking_lot_core::{FilterOp, ParkResult, ParkToken, DEFAULT_UNPARK_TOKEN};
+
+#[inline]
+fn key() -> usize {
+    // The EPOCH_CLOCK global is used as the key. This ties everything in this swym instance
+    // together into the same queue.
+    &EPOCH_CLOCK as *const _ as usize
+}
+
+#[inline(never)]
+#[cold]
+pub fn park<'tx, 'tcell>(pin: &PinMutRef<'tx, 'tcell>) {
+    // TODO: stats
+
+    unsafe {
+        let key = key();
+        let park_token = ParkToken(pin.park_token());
+        let validate = move || pin.park_validate();
+        let before_sleep = || {};
+        let timed_out = |_, _| {};
+        match parking_lot_core::park(key, validate, before_sleep, timed_out, park_token, None) {
+            ParkResult::Unparked(token) => debug_assert_eq!(token, DEFAULT_UNPARK_TOKEN),
+            ParkResult::Invalid => {}
+            ParkResult::TimedOut => {
+                if cfg!(debug_assertions) {
+                    panic!("unexpected timeout on parked thread")
+                }
+            }
+        }
+    }
+}
+
+#[inline(never)]
+#[cold]
+pub fn unpark() {
+    let key = key();
+    unsafe {
+        let filter = move |ParkToken(token)| {
+            if PinRef::should_unpark(token) {
+                FilterOp::Unpark
+            } else {
+                FilterOp::Skip
+            }
+        };
+        let callback = |_| DEFAULT_UNPARK_TOKEN;
+        let _unpark_result = parking_lot_core::unpark_filter(key, filter, callback);
+        // TODO: stats logging
+    }
+}

--- a/src/internal/parking.rs
+++ b/src/internal/parking.rs
@@ -14,29 +14,27 @@ fn key() -> usize {
 #[inline(never)]
 #[cold]
 pub fn park<'tx, 'tcell>(pin: &PinMutRef<'tx, 'tcell>) {
-    if pin.parkable() {
-        // TODO: stats
-        unsafe {
-            let key = key();
-            let park_token = ParkToken(pin.park_token());
-            let validate = move || pin.park_validate();
-            let before_sleep = || {};
-            let timed_out = |_, _| {};
-            match parking_lot_core::park(key, validate, before_sleep, timed_out, park_token, None) {
-                ParkResult::Unparked(token) => debug_assert_eq!(token, DEFAULT_UNPARK_TOKEN),
-                ParkResult::Invalid => {}
-                ParkResult::TimedOut => {
-                    if cfg!(debug_assertions) {
-                        panic!("unexpected timeout on parked thread")
-                    }
+    debug_assert!(
+        pin.parkable(),
+        "`RETRY` on a transaction that has an empty read set causes the thread to sleep forever \
+         in release"
+    );
+    // TODO: stats
+    unsafe {
+        let key = key();
+        let park_token = ParkToken(pin.park_token());
+        let validate = move || pin.park_validate();
+        let before_sleep = || {};
+        let timed_out = |_, _| {};
+        match parking_lot_core::park(key, validate, before_sleep, timed_out, park_token, None) {
+            ParkResult::Unparked(token) => debug_assert_eq!(token, DEFAULT_UNPARK_TOKEN),
+            ParkResult::Invalid => {}
+            ParkResult::TimedOut => {
+                if cfg!(debug_assertions) {
+                    panic!("unexpected timeout on parked thread")
                 }
             }
         }
-    } else {
-        panic!(
-            "requesting a RETRY on a transaction with an empty read and write set puts the thread \
-             to sleep forever"
-        );
     }
 }
 

--- a/src/internal/parking.rs
+++ b/src/internal/parking.rs
@@ -14,23 +14,29 @@ fn key() -> usize {
 #[inline(never)]
 #[cold]
 pub fn park<'tx, 'tcell>(pin: &PinMutRef<'tx, 'tcell>) {
-    // TODO: stats
-
-    unsafe {
-        let key = key();
-        let park_token = ParkToken(pin.park_token());
-        let validate = move || pin.park_validate();
-        let before_sleep = || {};
-        let timed_out = |_, _| {};
-        match parking_lot_core::park(key, validate, before_sleep, timed_out, park_token, None) {
-            ParkResult::Unparked(token) => debug_assert_eq!(token, DEFAULT_UNPARK_TOKEN),
-            ParkResult::Invalid => {}
-            ParkResult::TimedOut => {
-                if cfg!(debug_assertions) {
-                    panic!("unexpected timeout on parked thread")
+    if pin.parkable() {
+        // TODO: stats
+        unsafe {
+            let key = key();
+            let park_token = ParkToken(pin.park_token());
+            let validate = move || pin.park_validate();
+            let before_sleep = || {};
+            let timed_out = |_, _| {};
+            match parking_lot_core::park(key, validate, before_sleep, timed_out, park_token, None) {
+                ParkResult::Unparked(token) => debug_assert_eq!(token, DEFAULT_UNPARK_TOKEN),
+                ParkResult::Invalid => {}
+                ParkResult::TimedOut => {
+                    if cfg!(debug_assertions) {
+                        panic!("unexpected timeout on parked thread")
+                    }
                 }
             }
         }
+    } else {
+        panic!(
+            "requesting a RETRY on a transaction with an empty read and write set puts the thread \
+             to sleep forever"
+        );
     }
 }
 

--- a/src/internal/parking.rs
+++ b/src/internal/parking.rs
@@ -1,4 +1,5 @@
 use crate::internal::{epoch::EPOCH_CLOCK, thread::PinMutRef};
+use crossbeam_utils::Backoff;
 use parking_lot_core::{FilterOp, ParkResult, ParkToken, DEFAULT_UNPARK_TOKEN};
 
 #[inline]
@@ -8,29 +9,68 @@ fn key() -> usize {
     &EPOCH_CLOCK as *const _ as usize
 }
 
+#[inline]
+fn parkable<'tx, 'tcell>(pin: PinMutRef<'tx, 'tcell>) -> bool {
+    let logs = pin.logs();
+    !logs.read_log.is_empty() || !logs.write_log.is_empty()
+}
+
+#[inline]
+fn park_validate<'tx, 'tcell>(pin: PinMutRef<'tx, 'tcell>) -> bool {
+    // TODO: backup pin_epoch, and unpin, allowing GC to happen
+
+    let logs = pin.logs();
+    let pin_epoch = pin.pin_epoch();
+    if logs.read_log.try_clear_unpark_bits(pin_epoch) {
+        if logs.write_log.try_clear_unpark_bits(pin_epoch) {
+            true
+        } else {
+            logs.read_log.set_unpark_bits();
+            false
+        }
+    } else {
+        false
+    }
+}
+
+#[inline]
+unsafe fn should_unpark(ParkToken(token): ParkToken) -> bool {
+    let target = PinMutRef::from_park_token(token);
+
+    let logs = target.logs();
+    // TODO: use backup pin_epoch
+    let pin_epoch = target.pin_epoch();
+    !logs.read_log.validate_reads(pin_epoch) || !logs.write_log.validate_writes(pin_epoch)
+}
+
 #[inline(never)]
 #[cold]
-pub fn park<'tx, 'tcell>(pin: &PinMutRef<'tx, 'tcell>) {
+pub fn park<'tx, 'tcell>(mut pin: PinMutRef<'tx, 'tcell>, backoff: &Backoff) {
     debug_assert!(
-        pin.parkable(),
+        parkable(pin.reborrow()),
         "`RETRY` on a transaction that has an empty read set causes the thread to sleep forever \
          in release"
     );
+
     // TODO: stats
     // TODO: Attempt htm tag_parked
-    unsafe {
-        let key = key();
-        let park_token = ParkToken(pin.park_token());
-        let validate = move || pin.park_validate();
-        let before_sleep = || {};
-        let timed_out = |_, _| {};
-        match parking_lot_core::park(key, validate, before_sleep, timed_out, park_token, None) {
-            ParkResult::Unparked(token) => debug_assert_eq!(token, DEFAULT_UNPARK_TOKEN),
-            ParkResult::Invalid => {}
-            ParkResult::TimedOut => {
-                if cfg!(debug_assertions) {
-                    panic!("unexpected timeout on parked thread")
-                }
+    let key = key();
+    let park_token = ParkToken(pin.park_token());
+    let validate = move || park_validate(pin);
+    let before_sleep = || {};
+    let timed_out = |_, _| {};
+
+    match unsafe {
+        parking_lot_core::park(key, validate, before_sleep, timed_out, park_token, None)
+    } {
+        ParkResult::Unparked(token) => {
+            debug_assert_eq!(token, DEFAULT_UNPARK_TOKEN);
+            backoff.reset()
+        }
+        ParkResult::Invalid => backoff.snooze(),
+        ParkResult::TimedOut => {
+            if cfg!(debug_assertions) {
+                panic!("unexpected timeout on parked thread")
             }
         }
     }
@@ -40,16 +80,16 @@ pub fn park<'tx, 'tcell>(pin: &PinMutRef<'tx, 'tcell>) {
 #[cold]
 pub fn unpark() {
     let key = key();
-    unsafe {
-        let filter = move |ParkToken(token)| {
-            if PinMutRef::should_unpark(token) {
+    let callback = |_| DEFAULT_UNPARK_TOKEN;
+    let _unpark_result = unsafe {
+        let filter = move |token| {
+            if should_unpark(token) {
                 FilterOp::Unpark
             } else {
                 FilterOp::Skip
             }
         };
-        let callback = |_| DEFAULT_UNPARK_TOKEN;
-        let _unpark_result = parking_lot_core::unpark_filter(key, filter, callback);
-        // TODO: stats logging
-    }
+        parking_lot_core::unpark_filter(key, filter, callback)
+    };
+    // TODO: stats logging
 }

--- a/src/internal/parking.rs
+++ b/src/internal/parking.rs
@@ -1,7 +1,4 @@
-use crate::internal::{
-    epoch::EPOCH_CLOCK,
-    thread::{PinMutRef, PinRef},
-};
+use crate::internal::{epoch::EPOCH_CLOCK, thread::PinMutRef};
 use parking_lot_core::{FilterOp, ParkResult, ParkToken, DEFAULT_UNPARK_TOKEN};
 
 #[inline]
@@ -20,6 +17,7 @@ pub fn park<'tx, 'tcell>(pin: &PinMutRef<'tx, 'tcell>) {
          in release"
     );
     // TODO: stats
+    // TODO: Attempt htm tag_parked
     unsafe {
         let key = key();
         let park_token = ParkToken(pin.park_token());
@@ -44,7 +42,7 @@ pub fn unpark() {
     let key = key();
     unsafe {
         let filter = move |ParkToken(token)| {
-            if PinRef::should_unpark(token) {
+            if PinMutRef::should_unpark(token) {
                 FilterOp::Unpark
             } else {
                 FilterOp::Skip

--- a/src/internal/read_log.rs
+++ b/src/internal/read_log.rs
@@ -117,23 +117,25 @@ impl<'tcell> ReadLog<'tcell> {
     }
 
     #[inline]
-    pub fn park_reads(&self, pin_epoch: QuiesceEpoch) -> bool {
+    pub fn try_clear_unpark_bits(&self, pin_epoch: QuiesceEpoch) -> bool {
         for logged_read in self.iter() {
             if !logged_read.current_epoch.try_clear_unpark_bit(pin_epoch) {
-                self.unpark_reads_until(logged_read);
+                self.set_unpark_bits_until(logged_read);
                 return false;
             }
         }
         true
     }
 
-    fn unpark_reads_until(&self, end: &TCellErased) {
+    #[inline]
+    fn set_unpark_bits_until(&self, end: &TCellErased) {
         for logged_read in self.iter().take_while(|read| !ptr::eq(*read, end)) {
             logged_read.current_epoch.set_unpark_bit()
         }
     }
 
-    pub fn unpark_reads(&self) {
+    #[inline]
+    pub fn set_unpark_bits(&self) {
         for logged_read in self.iter() {
             logged_read.current_epoch.set_unpark_bit()
         }

--- a/src/internal/read_log.rs
+++ b/src/internal/read_log.rs
@@ -120,6 +120,7 @@ impl<'tcell> ReadLog<'tcell> {
     pub fn try_clear_unpark_bits(&self, pin_epoch: QuiesceEpoch) -> bool {
         for logged_read in self.iter() {
             if !logged_read.current_epoch.try_clear_unpark_bit(pin_epoch) {
+                // TODO: don't think this is correct
                 self.set_unpark_bits_until(logged_read);
                 return false;
             }

--- a/src/internal/read_log.rs
+++ b/src/internal/read_log.rs
@@ -119,7 +119,7 @@ impl<'tcell> ReadLog<'tcell> {
     #[inline]
     pub fn park_reads(&self, pin_epoch: QuiesceEpoch) -> bool {
         for logged_read in self.iter() {
-            if !logged_read.current_epoch.tag_parked(pin_epoch) {
+            if !logged_read.current_epoch.try_clear_unpark_bit(pin_epoch) {
                 self.unpark_reads_until(logged_read);
                 return false;
             }
@@ -129,13 +129,13 @@ impl<'tcell> ReadLog<'tcell> {
 
     fn unpark_reads_until(&self, end: &TCellErased) {
         for logged_read in self.iter().take_while(|read| !ptr::eq(*read, end)) {
-            logged_read.current_epoch.untag_parked()
+            logged_read.current_epoch.set_unpark_bit()
         }
     }
 
     pub fn unpark_reads(&self) {
         for logged_read in self.iter() {
-            logged_read.current_epoch.untag_parked()
+            logged_read.current_epoch.set_unpark_bit()
         }
     }
 }

--- a/src/internal/read_log.rs
+++ b/src/internal/read_log.rs
@@ -98,7 +98,7 @@ impl<'tcell> ReadLog<'tcell> {
     }
 
     #[inline]
-    pub fn validate_reads_htm(&self, pin_epoch: QuiesceEpoch, htm: &HardwareTx) {
+    pub fn validate_reads_htm(&self, pin_epoch: QuiesceEpoch, htx: &HardwareTx) {
         for logged_read in self.data.iter().rev() {
             let logged_read = match *logged_read {
                 Some(logged_read) => logged_read,
@@ -115,8 +115,17 @@ impl<'tcell> ReadLog<'tcell> {
                 },
             };
             if unlikely!(!pin_epoch.read_write_valid_lockable(&logged_read.current_epoch)) {
-                htm.abort()
+                htx.abort()
             }
+        }
+    }
+
+    #[inline]
+    pub fn clear_unpark_bits_htm(&self, pin_epoch: QuiesceEpoch, htx: &HardwareTx) {
+        for logged_read in self.iter() {
+            logged_read
+                .current_epoch
+                .clear_unpark_bit_htm(pin_epoch, htx)
         }
     }
 

--- a/src/internal/thread.rs
+++ b/src/internal/thread.rs
@@ -571,7 +571,7 @@ impl<'tx, 'tcell> PinRw<'tx, 'tcell> {
             //
             // TODO: would commit algorithm be faster with a single global lock, or lock striping?
             // per object locking causes a cmpxchg per entry
-            if let Some(park_status) = self.logs().write_log.try_lock_entries(self.pin_epoch()) {
+            if let Some(park_status) = self.logs().write_log.try_lock(self.pin_epoch()) {
                 self.write_log_lock_success(park_status)
             } else {
                 self.write_log_lock_failure()
@@ -627,7 +627,7 @@ impl<'tx, 'tcell> PinRw<'tx, 'tcell> {
     #[cold]
     unsafe fn validation_failure(self) -> bool {
         // on fail unlock the write set
-        self.logs().write_log.unlock_entries();
+        self.logs().write_log.unlock();
         false
     }
 }

--- a/src/internal/thread.rs
+++ b/src/internal/thread.rs
@@ -208,6 +208,12 @@ impl<'tx, 'tcell> PinRef<'tx, 'tcell> {
         let pin_epoch = self.pin_epoch();
         logs.read_log.validate_reads(pin_epoch) && logs.write_log.validate_writes(pin_epoch)
     }
+
+    #[inline]
+    pub fn parkable(&self) -> bool {
+        let logs = self.logs();
+        !logs.read_log.is_empty() || !logs.write_log.is_empty()
+    }
 }
 
 impl PinRef<'_, '_> {

--- a/src/internal/thread.rs
+++ b/src/internal/thread.rs
@@ -203,7 +203,6 @@ impl<'tx, 'tcell> PinRef<'tx, 'tcell> {
 
     #[inline]
     pub fn park_validate(&self) -> bool {
-        // false
         // TODO: backup pin_epoch, and unpin, allowing GC to happen
         let logs = self.logs();
         let pin_epoch = self.pin_epoch();

--- a/src/internal/thread.rs
+++ b/src/internal/thread.rs
@@ -126,11 +126,7 @@ impl<'tcell> Logs<'tcell> {
             if write_log.find(src).is_none() {
                 true
             } else {
-                // don't capture count in release
-                #[cfg(feature = "stats")]
-                {
-                    count += 1;
-                }
+                count += 1;
                 false
             }
         });

--- a/src/internal/thread.rs
+++ b/src/internal/thread.rs
@@ -380,6 +380,9 @@ impl<'tcell> Pin<'tcell> {
                     }
                     Err(Error::RETRY) => {
                         crate::internal::parking::park(&pin);
+                        backoff.reset();
+                        // no need to snooze
+                        continue;
                     }
                 }
             }

--- a/src/internal/usize_aligned.rs
+++ b/src/internal/usize_aligned.rs
@@ -53,7 +53,7 @@ impl<T> ForcedUsizeAligned<T> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::mem;
+    use core::mem;
 
     #[test]
     fn alignment() {

--- a/src/internal/write_log.rs
+++ b/src/internal/write_log.rs
@@ -388,42 +388,6 @@ impl<'tcell> WriteLog<'tcell> {
             epoch_lock.unlock_publish(publish_epoch);
         }
     }
-
-    #[inline]
-    pub fn clear_unpark_bits_htm(&self, pin_epoch: QuiesceEpoch, htx: &HardwareTx) {
-        for epoch_lock in self.epoch_locks() {
-            epoch_lock.clear_unpark_bit_htm(pin_epoch, htx)
-        }
-    }
-
-    #[inline]
-    pub fn try_clear_unpark_bits(&self, pin_epoch: QuiesceEpoch) -> bool {
-        let mut park_statuses = Vec::new();
-        for epoch_lock in self.epoch_locks() {
-            let park_status = epoch_lock.try_clear_unpark_bit(pin_epoch);
-            match park_status {
-                Some(status) => park_statuses.push(status),
-                None => {
-                    self.set_unpark_bits_until(epoch_lock, park_statuses);
-                    return false;
-                }
-            }
-        }
-        true
-    }
-
-    #[inline]
-    fn set_unpark_bits_until(&self, end: &EpochLock, park_statuses: Vec<ParkStatus>) {
-        for (epoch_lock, park_status) in self
-            .epoch_locks()
-            .take_while(move |&e| !ptr::eq(e, end))
-            .zip(park_statuses)
-        {
-            if park_status != ParkStatus::HasParked {
-                epoch_lock.set_unpark_bit();
-            }
-        }
-    }
 }
 
 pub enum Entry<'a, 'tcell> {

--- a/src/internal/write_log.rs
+++ b/src/internal/write_log.rs
@@ -390,6 +390,13 @@ impl<'tcell> WriteLog<'tcell> {
     }
 
     #[inline]
+    pub fn clear_unpark_bits_htm(&self, pin_epoch: QuiesceEpoch, htx: &HardwareTx) {
+        for epoch_lock in self.epoch_locks() {
+            epoch_lock.clear_unpark_bit_htm(pin_epoch, htx)
+        }
+    }
+
+    #[inline]
     pub fn try_clear_unpark_bits(&self, pin_epoch: QuiesceEpoch) -> bool {
         let mut park_statuses = Vec::new();
         for epoch_lock in self.epoch_locks() {

--- a/src/internal/write_log.rs
+++ b/src/internal/write_log.rs
@@ -188,6 +188,13 @@ impl<'tcell> WriteLog<'tcell> {
     }
 
     #[inline]
+    pub unsafe fn drop_writes(&mut self) {
+        for mut elem in self.data.iter_mut() {
+            ptr::drop_in_place::<dyn WriteEntry>(&mut *elem)
+        }
+    }
+
+    #[inline]
     pub fn is_empty(&self) -> bool {
         let empty = self.filter == 0;
         debug_assert_eq!(

--- a/src/internal/write_log.rs
+++ b/src/internal/write_log.rs
@@ -383,10 +383,10 @@ impl<'tcell> WriteLog<'tcell> {
     }
 
     #[inline]
-    pub fn park_writes(&self, pin_epoch: QuiesceEpoch) -> bool {
+    pub fn try_clear_unpark_bits(&self, pin_epoch: QuiesceEpoch) -> bool {
         for epoch_lock in self.epoch_locks() {
             if !epoch_lock.try_clear_unpark_bit(pin_epoch) {
-                self.unpark_until(epoch_lock);
+                self.set_unpark_bits_until(epoch_lock);
                 return false;
             }
         }
@@ -394,7 +394,7 @@ impl<'tcell> WriteLog<'tcell> {
     }
 
     #[inline]
-    pub fn unpark_until(&self, end: &EpochLock) {
+    pub fn set_unpark_bits_until(&self, end: &EpochLock) {
         for epoch_lock in self.epoch_locks().take_while(move |&e| !ptr::eq(e, end)) {
             epoch_lock.set_unpark_bit();
         }

--- a/src/internal/write_log.rs
+++ b/src/internal/write_log.rs
@@ -385,7 +385,7 @@ impl<'tcell> WriteLog<'tcell> {
     #[inline]
     pub fn park_writes(&self, pin_epoch: QuiesceEpoch) -> bool {
         for epoch_lock in self.epoch_locks() {
-            if !epoch_lock.tag_parked(pin_epoch) {
+            if !epoch_lock.try_clear_unpark_bit(pin_epoch) {
                 self.unpark_until(epoch_lock);
                 return false;
             }
@@ -396,7 +396,7 @@ impl<'tcell> WriteLog<'tcell> {
     #[inline]
     pub fn unpark_until(&self, end: &EpochLock) {
         for epoch_lock in self.epoch_locks().take_while(move |&e| !ptr::eq(e, end)) {
-            epoch_lock.untag_parked();
+            epoch_lock.set_unpark_bit();
         }
     }
 }

--- a/src/internal/write_log.rs
+++ b/src/internal/write_log.rs
@@ -206,7 +206,7 @@ impl<'tcell> WriteLog<'tcell> {
     }
 
     #[inline]
-    fn epoch_locks(&self) -> impl Iterator<Item = &EpochLock> {
+    pub fn epoch_locks(&self) -> impl Iterator<Item = &EpochLock> {
         self.data
             .iter()
             .flat_map(|entry| entry.tcell().map(|erased| &erased.current_epoch))

--- a/src/internal/write_log.rs
+++ b/src/internal/write_log.rs
@@ -336,7 +336,6 @@ impl<'tcell> WriteLog<'tcell> {
                     }
                     return None;
                 }
-
             }
         }
         Some(status)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@
 //! * Highly optimized for read mostly data structures and modern caches. `TCell` stores all of its
 //!   data inline. Read only transactions don't modify any global state, and read write transactions
 //!   only modify global state on commit.
+//! * Parking retry is supported via [`AWAIT_RETRY`](crate::tx::Status::AWAIT_RETRY).
 //! * The number of allocations imposed by swym per transaction should average 0 through reuse of
 //!   read logs/write logs/garbage bags.
 //! * Support for building recursive data structures using `TPtr` is still experimental but looks

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //!     Ok(())
 //! });
 //! assert_eq!(b.into_inner(), 0);
-//! assert_eq!(thread_key.read(|tx| A.get(tx, Default::default())), 42);
+//! assert_eq!(thread_key.read(|tx| Ok(A.get(tx, Default::default())?)), 42);
 //! ```
 //!
 //! # Features

--- a/src/read.rs
+++ b/src/read.rs
@@ -64,7 +64,7 @@ impl<'tcell> Read<'tcell> for ReadTx<'tcell> {
                 {
                     Ok(value)
                 } else {
-                    Err(Error::RETRY)
+                    Err(Error::CONFLICT)
                 }
             } else {
                 // If the type is zero sized, there's no need to any synchronization.

--- a/src/rw.rs
+++ b/src/rw.rs
@@ -83,7 +83,7 @@ impl<'tx, 'tcell> RwTxImpl<'tx, 'tcell> {
                 }
             }
         }
-        Err(Error::RETRY)
+        Err(Error::CONFLICT)
     }
 
     #[inline]
@@ -126,7 +126,7 @@ impl<'tx, 'tcell> RwTxImpl<'tx, 'tcell> {
                 }
             }
         }
-        Err(Error::RETRY)
+        Err(Error::CONFLICT)
     }
 
     #[inline]
@@ -179,7 +179,7 @@ impl<'tx, 'tcell> RwTxImpl<'tx, 'tcell> {
             mem::forget(value);
             Err(SetError {
                 value: casted,
-                error: Error::RETRY,
+                error: Error::CONFLICT,
             })
         }
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -190,22 +190,24 @@ stats! {
     /// Number of times a garbage collection cycle hit the maximum Backoff during quiescing.
     should_park_gc:                     Size @ SHOULD_PARK_GC,
 
-    /// Number of threads awaiting retry ([`AWAIT_RETRY`]) woken up per call to unpark.
+    /// Number of threads awaiting retry ([`AWAIT_RETRY`](crate::tx::Status::AWAIT_RETRY)) woken up
+    /// per call to unpark.
     unparked_size:                      Size @ UNPARKED_SIZE,
 
-    /// Number of threads awaiting retry ([`AWAIT_RETRY`]) that were _not_ woken up per call to
-    /// unpark.
+    /// Number of threads awaiting retry ([`AWAIT_RETRY`](crate::tx::Status::AWAIT_RETRY)) that were
+    /// _not_ woken up per call to unpark.
     not_unparked_size:                  Size @ NOT_UNPARKED_SIZE,
 
-    /// When a thread attempts to [`AWAIT_RETRY`], this is the number of times it attempted a HTM
-    /// park, and failed.
+    /// When a thread attempts to [`AWAIT_RETRY`](crate::tx::Status::AWAIT_RETRY), this is the
+    /// number of times it attempted a HTM park, and failed.
     htm_park_conflicts:                 Size @ HTM_PARK_CONFLICTS,
 
-    /// When a thread attempts to [`AWAIT_RETRY`], but one of the waited on `EpochLock`'s gets
-    /// modified before being parked.
+    /// When a thread attempts to [`AWAIT_RETRY`](crate::tx::Status::AWAIT_RETRY), but one of the
+    /// waited on `EpochLock`'s gets modified before being parked.
     park_failure_size:                  Size @ PARK_FAILURE_SIZE,
 
-    /// Number of `EpochLock`s a parked (via [`AWAIT_RETRY`]) thread can be woken up from.
+    /// Number of `EpochLock`s a parked (via [`AWAIT_RETRY`](crate::tx::Status::AWAIT_RETRY)) thread
+    /// can be woken up from.
     parked_size:                        Size @ PARKED_SIZE,
 }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -85,21 +85,27 @@ impl Event {
     }
 }
 
+macro_rules! env_var_set {
+    ($env_var:ident) => {
+        option_env!(concat!("SWYM_", stringify!($env_var))) == Some("1")
+    };
+}
+
 macro_rules! stats_func {
-    ($(#[$attr:meta])* $name:ident: Event) => {
+    ($(#[$attr:meta])* $name:ident: Event @ $env_var:ident) => {
         #[inline]
         $(#[$attr])*
         pub(crate) fn $name() {
-            if cfg!(feature = "stats") {
+            if cfg!(feature = "stats") || env_var_set!($env_var) {
                 THREAD_STAT.get().get().$name.happened()
             }
         }
     };
-    ($(#[$attr:meta])* $name:ident: Size) => {
+    ($(#[$attr:meta])* $name:ident: Size @ $env_var:ident) => {
         #[inline]
         $(#[$attr])*
         pub(crate) fn $name(size: usize) {
-            if cfg!(feature = "stats") {
+            if cfg!(feature = "stats") || env_var_set!($env_var) {
                 let size = size as u64;
                 THREAD_STAT.with(move |x| x.get().$name.record(size))
             }
@@ -108,7 +114,7 @@ macro_rules! stats_func {
 }
 
 macro_rules! stats {
-    ($($(#[$attr:meta])* $names:ident: $kinds:tt),* $(,)*) => {
+    ($($(#[$attr:meta])* $names:ident: $kinds:tt @ $env_var:ident),* $(,)*) => {
         /// A collection of swym statistics.
         #[derive(Default, Debug)]
         pub struct Stats {
@@ -123,61 +129,65 @@ macro_rules! stats {
             }
         }
 
-        $(stats_func!{$(#[$attr])* $names: $kinds})*
+        fn any_stats_active() -> bool {
+            cfg!(feature = "stats") $(|| env_var_set!($env_var))*
+        }
+
+        $(stats_func!{$(#[$attr])* $names: $kinds @ $env_var})*
     };
 }
 
 stats! {
-    /// Number of retries per successful read transaction.
-    read_transaction_retries:         Size,
+    /// Number of conflicts per successful read transaction.
+    read_transaction_conflicts:         Size @ READ_TRANSACTION_CONFLICTS,
 
-    /// Number of eager (before commit) retries per successful write transaction.
-    write_transaction_eager_retries:  Size,
+    /// Number of eager (before commit) conflicts per successful write transaction.
+    write_transaction_eager_conflicts:  Size @ WRITE_TRANSACTION_EAGER_CONFLICTS,
 
-    /// Number of commit retries per successful write transaction.
-    write_transaction_commit_retries: Size,
+    /// Number of commit conflicts per successful write transaction.
+    write_transaction_commit_conflicts: Size @ WRITE_TRANSACTION_COMMIT_CONFLICTS,
 
-    /// Number of hardware retries per successful hardware transaction or software fallback.
+    /// Number of hardware conflicts per successful hardware transaction or software fallback.
     ///
-    /// This is a less obvious metric. If a transaction completely fails and retries from the start
+    /// This is a less obvious metric. If a transaction completely fails and conflicts from the start
     /// 10 times, each one attempting a hardware commit, then this will be recorded 10 times with
     /// 10 different values.
-    htm_retries:                      Size,
+    htm_conflicts:                      Size @ HTM_CONFLICTS,
 
     /// Number of `TCell`s in the read log at commit time.
-    read_size:                        Size,
+    read_size:                        Size @ READ_SIZE,
 
     /// Number of cpu words in the write log at commit time. Each write is a minimum of 3 words.
-    write_word_size:                  Size,
+    write_word_size:                  Size @ WRITE_WORD_SIZE,
 
     /// A bloom filter check.
-    bloom_check:                      Event,
+    bloom_check:                      Event @ BLOOM_CHECK,
 
     /// A bloom filter collision.
-    bloom_collision:                  Event,
+    bloom_collision:                  Event @ BLOOM_CHECK,
 
     /// A bloom filter hit that required a full lookup to verify.
-    bloom_success_slow:               Event,
+    bloom_success_slow:               Event @ BLOOM_SUCCESS_SLOW,
 
     /// A transactional read of data that exists in the write log. Considered slow.
-    read_after_write:                 Event,
+    read_after_write:                 Event @ READ_AFTER_WRITE,
 
     /// A transactional overwrite of data that exists in the write log. Considered slow.
-    write_after_write:                Event,
+    write_after_write:                Event @ WRITE_AFTER_WRITE,
 
     /// Number of transactional writes to data that has been logged as read from first. Considered slowish.
     ///
     /// Writes after logged reads currently causes the commit algorithm to do more work.
-    write_after_logged_read:          Size,
+    write_after_logged_read:          Size @ WRITE_AFTER_LOGGED_READ,
 
     /// Number of times a read transaction hit the maximum Backoff.
-    should_park_read:                 Size,
+    should_park_read:                 Size @ SHOULD_PARK_READ,
 
     /// Number of times a read/write transaction hit the maximum Backoff.
-    should_park_write:                Size,
+    should_park_write:                Size @ SHOULD_PARK_WRITE,
 
     /// Number of times a garbage collection cycle hit the maximum Backoff during quiescing.
-    should_park_gc:                   Size,
+    should_park_gc:                   Size @ SHOULD_PARK_GC,
 }
 
 impl Stats {
@@ -185,23 +195,23 @@ impl Stats {
     pub fn print_summary(&self) {
         println!("{:#?}", self);
 
-        // Retries are recorded once after the transaction has completed. Eager retries and commit
-        // retries are recorded in equal amounts, so just picking one of them is correct here.
+        // Retries are recorded once after the transaction has completed. Eager conflicts and commit
+        // conflicts are recorded in equal amounts, so just picking one of them is correct here.
         let successful_transactions =
-            self.read_transaction_retries.count + self.write_transaction_eager_retries.count;
+            self.read_transaction_conflicts.count + self.write_transaction_eager_conflicts.count;
 
-        let retries = self
-            .read_transaction_retries
+        let conflicts = self
+            .read_transaction_conflicts
             .min_max_total
             .unwrap_or_default()
             .total
             + self
-                .write_transaction_eager_retries
+                .write_transaction_eager_conflicts
                 .min_max_total
                 .unwrap_or_default()
                 .total
             + self
-                .write_transaction_commit_retries
+                .write_transaction_commit_conflicts
                 .min_max_total
                 .unwrap_or_default()
                 .total;
@@ -209,10 +219,10 @@ impl Stats {
             "{:>12}: {:>12} {:>9}: {:.4} {:>13}: {:.4}",
             "transactions",
             successful_transactions,
-            "retry avg",
-            retries as f64 / successful_transactions as f64,
-            "htm retry avg",
-            self.htm_retries.min_max_total.unwrap_or_default().total as f64
+            "conflict avg",
+            conflicts as f64 / successful_transactions as f64,
+            "htm conflict avg",
+            self.htm_conflicts.min_max_total.unwrap_or_default().total as f64
                 / successful_transactions as f64
         );
         println!(
@@ -280,7 +290,7 @@ lazy_static::lazy_static! {
 
 /// Returns the global stats object, or None if the feature is disabled.
 pub fn stats() -> Option<impl Deref<Target = Stats>> {
-    if cfg!(feature = "stats") {
+    if any_stats_active() {
         Some(GLOBAL.lock())
     } else {
         None
@@ -289,7 +299,7 @@ pub fn stats() -> Option<impl Deref<Target = Stats>> {
 
 /// Returns the thread local stats object, or None if the feature is disabled.
 pub fn thread_stats() -> Option<impl Deref<Target = ThreadStats>> {
-    if cfg!(feature = "stats") {
+    if any_stats_active() {
         Some(THREAD_STAT.get())
     } else {
         None

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -197,6 +197,10 @@ stats! {
     /// unpark.
     not_unparked_size:                  Size @ NOT_UNPARKED_SIZE,
 
+    /// When a thread attempts to [`AWAIT_RETRY`], this is the number of times it attempted a HTM
+    /// park, and failed.
+    htm_park_conflicts:                 Size @ HTM_PARK_CONFLICTS,
+
     /// When a thread attempts to [`AWAIT_RETRY`], but one of the waited on `EpochLock`'s gets
     /// modified before being parked.
     park_failure_size:                  Size @ PARK_FAILURE_SIZE,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -188,6 +188,12 @@ stats! {
 
     /// Number of times a garbage collection cycle hit the maximum Backoff during quiescing.
     should_park_gc:                   Size @ SHOULD_PARK_GC,
+
+    /// Number of threads awaiting retry ([`AWAIT_RETRY`]) woken up per call to unpark.
+    unparked_size:                    Size @ UNPARKED_SIZE,
+
+    /// Number of threads awaiting retry ([`AWAIT_RETRY`]) that were _not_ woken up per call to unpark.
+    not_unparked_size:                Size @ NOT_UNPARKED_SIZE,
 }
 
 impl Stats {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -149,51 +149,60 @@ stats! {
 
     /// Number of hardware conflicts per successful hardware transaction or software fallback.
     ///
-    /// This is a less obvious metric. If a transaction completely fails and conflicts from the start
-    /// 10 times, each one attempting a hardware commit, then this will be recorded 10 times with
-    /// 10 different values.
+    /// This is a less obvious metric. If a transaction completely fails and conflicts from the
+    /// start 10 times, each one attempting a hardware commit, then this will be recorded 10 times
+    /// with 10 different values.
     htm_conflicts:                      Size @ HTM_CONFLICTS,
 
     /// Number of `TCell`s in the read log at commit time.
-    read_size:                        Size @ READ_SIZE,
+    read_size:                          Size @ READ_SIZE,
 
     /// Number of cpu words in the write log at commit time. Each write is a minimum of 3 words.
-    write_word_size:                  Size @ WRITE_WORD_SIZE,
+    write_word_size:                    Size @ WRITE_WORD_SIZE,
 
     /// A bloom filter check.
-    bloom_check:                      Event @ BLOOM_CHECK,
+    bloom_check:                       Event @ BLOOM_CHECK,
 
     /// A bloom filter collision.
-    bloom_collision:                  Event @ BLOOM_CHECK,
+    bloom_collision:                   Event @ BLOOM_CHECK,
 
     /// A bloom filter hit that required a full lookup to verify.
-    bloom_success_slow:               Event @ BLOOM_SUCCESS_SLOW,
+    bloom_success_slow:                Event @ BLOOM_SUCCESS_SLOW,
 
     /// A transactional read of data that exists in the write log. Considered slow.
-    read_after_write:                 Event @ READ_AFTER_WRITE,
+    read_after_write:                  Event @ READ_AFTER_WRITE,
 
     /// A transactional overwrite of data that exists in the write log. Considered slow.
-    write_after_write:                Event @ WRITE_AFTER_WRITE,
+    write_after_write:                 Event @ WRITE_AFTER_WRITE,
 
-    /// Number of transactional writes to data that has been logged as read from first. Considered slowish.
+    /// Number of transactional writes to data that has been logged as read from first. Considered
+    /// slowish.
     ///
     /// Writes after logged reads currently causes the commit algorithm to do more work.
-    write_after_logged_read:          Size @ WRITE_AFTER_LOGGED_READ,
+    write_after_logged_read:            Size @ WRITE_AFTER_LOGGED_READ,
 
     /// Number of times a read transaction hit the maximum Backoff.
-    should_park_read:                 Size @ SHOULD_PARK_READ,
+    should_park_read:                   Size @ SHOULD_PARK_READ,
 
     /// Number of times a read/write transaction hit the maximum Backoff.
-    should_park_write:                Size @ SHOULD_PARK_WRITE,
+    should_park_write:                  Size @ SHOULD_PARK_WRITE,
 
     /// Number of times a garbage collection cycle hit the maximum Backoff during quiescing.
-    should_park_gc:                   Size @ SHOULD_PARK_GC,
+    should_park_gc:                     Size @ SHOULD_PARK_GC,
 
     /// Number of threads awaiting retry ([`AWAIT_RETRY`]) woken up per call to unpark.
-    unparked_size:                    Size @ UNPARKED_SIZE,
+    unparked_size:                      Size @ UNPARKED_SIZE,
 
-    /// Number of threads awaiting retry ([`AWAIT_RETRY`]) that were _not_ woken up per call to unpark.
-    not_unparked_size:                Size @ NOT_UNPARKED_SIZE,
+    /// Number of threads awaiting retry ([`AWAIT_RETRY`]) that were _not_ woken up per call to
+    /// unpark.
+    not_unparked_size:                  Size @ NOT_UNPARKED_SIZE,
+
+    /// When a thread attempts to [`AWAIT_RETRY`], but one of the waited on `EpochLock`'s gets
+    /// modified before being parked.
+    park_failure_size:                  Size @ PARK_FAILURE_SIZE,
+
+    /// Number of `EpochLock`s a parked (via [`AWAIT_RETRY`]) thread can be woken up from.
+    parked_size:                        Size @ PARKED_SIZE,
 }
 
 impl Stats {

--- a/src/tcell.rs
+++ b/src/tcell.rs
@@ -490,7 +490,7 @@ mod test {
     }
 
     #[test]
-    fn publish_retry() {
+    fn publish_conflict() {
         static TRIGGERED: AtomicBool = AtomicBool::new(false);
         let x = TCell::new(42);
 
@@ -508,7 +508,7 @@ mod test {
                                 TRIGGERED.store(true, Ordering::Relaxed);
                             }),
                         )?;
-                        Err(Error::RETRY)
+                        Err(Error::CONFLICT)
                     }
                 });
             });

--- a/src/tcell.rs
+++ b/src/tcell.rs
@@ -508,7 +508,7 @@ mod test {
                                 TRIGGERED.store(true, Ordering::Relaxed);
                             }),
                         )?;
-                        Err(Error::CONFLICT)
+                        Err(Error::CONFLICT.into())
                     }
                 });
             });
@@ -554,7 +554,7 @@ mod test {
                             }),
                         )?;
                         x.set(tx, 3)?;
-                        Err(Error::CONFLICT)
+                        Err(Error::CONFLICT.into())
                     }
                 });
             });

--- a/src/tcell.rs
+++ b/src/tcell.rs
@@ -554,7 +554,7 @@ mod test {
                             }),
                         )?;
                         x.set(tx, 3)?;
-                        Err(Error::RETRY)
+                        Err(Error::CONFLICT)
                     }
                 });
             });

--- a/src/thread_key.rs
+++ b/src/thread_key.rs
@@ -6,7 +6,7 @@ use crate::{
     internal::{phoenix_tls::Phoenix, thread::Thread},
     read::ReadTx,
     rw::RwTx,
-    tx::Status,
+    tx::{Error, Status},
 };
 use core::fmt::{self, Debug, Formatter};
 
@@ -49,7 +49,7 @@ impl ThreadKey {
     #[inline]
     pub fn read<'tcell, F, O>(&'tcell self, f: F) -> O
     where
-        F: FnMut(&ReadTx<'tcell>) -> Result<O, Status>,
+        F: FnMut(&ReadTx<'tcell>) -> Result<O, Error>,
     {
         self.try_read(f)
             .expect("nested transactions are not yet supported")
@@ -109,7 +109,7 @@ impl ThreadKey {
     #[inline]
     pub fn try_read<'tcell, F, O>(&'tcell self, f: F) -> Result<O, TryReadErr>
     where
-        F: FnMut(&ReadTx<'tcell>) -> Result<O, Status>,
+        F: FnMut(&ReadTx<'tcell>) -> Result<O, Error>,
     {
         Ok(self
             .thread

--- a/src/thread_key.rs
+++ b/src/thread_key.rs
@@ -6,7 +6,7 @@ use crate::{
     internal::{phoenix_tls::Phoenix, thread::Thread},
     read::ReadTx,
     rw::RwTx,
-    tx::Error,
+    tx::Status,
 };
 use core::fmt::{self, Debug, Formatter};
 
@@ -49,7 +49,7 @@ impl ThreadKey {
     #[inline]
     pub fn read<'tcell, F, O>(&'tcell self, f: F) -> O
     where
-        F: FnMut(&ReadTx<'tcell>) -> Result<O, Error>,
+        F: FnMut(&ReadTx<'tcell>) -> Result<O, Status>,
     {
         self.try_read(f)
             .expect("nested transactions are not yet supported")
@@ -80,7 +80,7 @@ impl ThreadKey {
     #[inline]
     pub fn rw<'tcell, F, O>(&'tcell self, f: F) -> O
     where
-        F: FnMut(&mut RwTx<'tcell>) -> Result<O, Error>,
+        F: FnMut(&mut RwTx<'tcell>) -> Result<O, Status>,
     {
         self.try_rw(f)
             .expect("nested transactions are not yet supported")
@@ -109,7 +109,7 @@ impl ThreadKey {
     #[inline]
     pub fn try_read<'tcell, F, O>(&'tcell self, f: F) -> Result<O, TryReadErr>
     where
-        F: FnMut(&ReadTx<'tcell>) -> Result<O, Error>,
+        F: FnMut(&ReadTx<'tcell>) -> Result<O, Status>,
     {
         Ok(self
             .thread
@@ -145,7 +145,7 @@ impl ThreadKey {
     #[inline]
     pub fn try_rw<'tcell, F, O>(&'tcell self, f: F) -> Result<O, TryRwErr>
     where
-        F: FnMut(&mut RwTx<'tcell>) -> Result<O, Error>,
+        F: FnMut(&mut RwTx<'tcell>) -> Result<O, Status>,
     {
         Ok(self
             .thread

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -113,7 +113,7 @@ impl Status {
     ///
     /// # Notes
     ///
-    /// Returning `RETRY` to [`ThreadKey::read`] or [`ThreadKey::rw`] will block the thread, until
+    /// Returning `AWAIT_RETRY` to [`ThreadKey::read`] or [`ThreadKey::rw`] will block the thread, until
     /// another transaction successfully modifies a `TCell` in this transactions read set.
     ///
     /// # Examples
@@ -126,7 +126,7 @@ impl Status {
     ///
     /// thread_key.rw(|tx| {
     ///     if locked.get(tx, Default::default())? {
-    ///         Err(Status::RETRY)
+    ///         Err(Status::AWAIT_RETRY)
     ///     } else {
     ///         Ok(locked.set(tx, true)?)
     ///     }
@@ -135,7 +135,7 @@ impl Status {
     ///
     /// [`ThreadKey::read`]: ../thread_key/struct.ThreadKey.html#method.read
     /// [`ThreadKey::rw`]: ../thread_key/struct.ThreadKey.html#method.rw
-    pub const RETRY: Self = Status {
+    pub const AWAIT_RETRY: Self = Status {
         kind: InternalStatus::Retry,
     };
 }

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -12,7 +12,7 @@ enum ErrorKind {
     Conflict,
 }
 
-/// Error type indicating that the transaction has failed.
+/// An error type indicating that the transaction has failed.
 ///
 /// It is typical to route this error back to [`ThreadKey::rw`] or [`ThreadKey::read`] where the
 /// transaction will be retried, however, this is not required.
@@ -49,7 +49,7 @@ impl Error {
     };
 }
 
-/// Error type indicating that the transaction has failed to [`set`] a value.
+/// An error type indicating that the transaction has failed to [`set`] a value.
 ///
 /// It is typical to convert this error [`into`] a [`Error`] and route it back to [`ThreadKey::rw`]
 /// where the transaction will be retried, however, this is not required.
@@ -87,6 +87,15 @@ pub(crate) enum InternalStatus {
     Retry,
 }
 
+/// A type representing that the transaction does not wish to continue.
+///
+/// `Status` may represent a transaction error, or that the transaction wishes to
+/// [`AWAIT_RETRY`](Status::AWAIT_RETRY).
+///
+/// It is typical to route this back to [`ThreadKey::rw`] where the transaction will be retried,
+/// however, this is not required.
+///
+/// [`ThreadKey::rw`]: ../thread_key/struct.ThreadKey.html#method.rw
 #[derive(Debug, PartialEq, Eq)]
 pub struct Status {
     pub(crate) kind: InternalStatus,
@@ -109,12 +118,10 @@ impl<T> From<SetError<T>> for Status {
 }
 
 impl Status {
-    /// `Status` value requesting a retry of the current transaction.
+    /// `Status` value requesting a retry of the current transaction after a change to the read set.
     ///
-    /// # Notes
-    ///
-    /// Returning `AWAIT_RETRY` to [`ThreadKey::read`] or [`ThreadKey::rw`] will block the thread,
-    /// until another transaction successfully modifies a `TCell` in this transactions read set.
+    /// Returning `AWAIT_RETRY` to [`ThreadKey::rw`] will block the thread, until another
+    /// transaction successfully modifies a `TCell` in this transactions read set.
     ///
     /// # Examples
     ///
@@ -133,7 +140,15 @@ impl Status {
     /// })
     /// ```
     ///
-    /// [`ThreadKey::read`]: ../thread_key/struct.ThreadKey.html#method.read
+    /// # Warning
+    ///
+    /// `AWAIT_RETRY` introduces the possibility of true deadlocks into `swym`. A program which does
+    /// not use `AWAIT_RETRY` will never deadlock - atleast due to `swym`. This is considered
+    /// "worth it" because many powerful abstractions can be built upon `AWAIT_RETRY`.
+    ///
+    /// A transaction which returns `AWAIT_RETRY` with an empty read set is considered a logic
+    /// error. In debug builds it will panic, and in release builds it will park the thread forever.
+    ///
     /// [`ThreadKey::rw`]: ../thread_key/struct.ThreadKey.html#method.rw
     pub const AWAIT_RETRY: Self = Status {
         kind: InternalStatus::Retry,
@@ -158,12 +173,15 @@ pub enum Ordering {
     /// serializability. This can significantly reduce the number of failed transactions
     /// resulting in noticeable performance improvement under heavy contention.
     ///
-    /// # Note
+    /// # Warning
     ///
     /// Profile before even considering this memory ordering. Use of `Ordering::Read` when combined
     /// with only safe code, will always be safe, but it can still cause extremely subtle bugs, as
     /// transactions will no longer behave as though a single global lock were acquired for the
     /// duration of the transaction.
+    ///
+    /// Additionally, reads using `Ordering::Read` will _not_ be waited on when using
+    /// [`AWAIT_RETRY`](crate::tx::Status::AWAIT_RETRY).
     ///
     /// # Examples
     ///

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -113,8 +113,8 @@ impl Status {
     ///
     /// # Notes
     ///
-    /// Returning `AWAIT_RETRY` to [`ThreadKey::read`] or [`ThreadKey::rw`] will block the thread, until
-    /// another transaction successfully modifies a `TCell` in this transactions read set.
+    /// Returning `AWAIT_RETRY` to [`ThreadKey::read`] or [`ThreadKey::rw`] will block the thread,
+    /// until another transaction successfully modifies a `TCell` in this transactions read set.
     ///
     /// # Examples
     ///

--- a/swym-htm/src/lib.rs
+++ b/swym-htm/src/lib.rs
@@ -208,6 +208,7 @@ impl HardwareTx {
     ///
     /// Even though this never returns, it does **not** panic.
     #[inline(always)]
+    #[cold]
     pub fn abort(&self) -> ! {
         unsafe { abort() }
     }

--- a/tests/unpark.rs
+++ b/tests/unpark.rs
@@ -2,7 +2,9 @@ mod unpark {
     use crossbeam_utils::thread;
     use swym::{tcell::TCell, thread_key, tx::Status};
 
+    #[cfg(debug_assertions)]
     #[test]
+    #[should_panic]
     fn empty_tx() {
         let key = thread_key::get();
         let () = key.rw(|_| Err(Status::AWAIT_RETRY));

--- a/tests/unpark.rs
+++ b/tests/unpark.rs
@@ -1,0 +1,77 @@
+mod unpark {
+    use crossbeam_utils::thread;
+    use swym::{tcell::TCell, thread_key, tx::Status};
+
+    // This test attempts to create a situation where a thread can fail to park on `a` & `b`.
+    // Specifically, parking validation fails on `b`. This causes the thread to try to clear the
+    // unpark bit it might have just set on `a`. This is incorrect if there is another thread parked
+    // on `a`.
+    #[test]
+    fn park_failure() {
+        const ITER: usize = 1_000;
+        const TRIES: usize = 100;
+
+        // if we haven't completed in a reasonable amount of time, abort, failing the test
+        std::thread::spawn(|| {
+            std::thread::sleep(std::time::Duration::from_secs(10));
+            std::process::abort();
+        });
+
+        for _ in 0..TRIES {
+            let a = TCell::new(0);
+            let b = TCell::new(0);
+
+            thread::scope(|s| {
+                // this thread updates b
+                s.spawn(|_| {
+                    let key = thread_key::get();
+                    for x in 0..=ITER {
+                        key.rw(|tx| {
+                            b.set(tx, x)?;
+                            Ok(())
+                        });
+                    }
+                });
+                // this thread attempts to ensure a == b
+                s.spawn(|_| {
+                    let key = thread_key::get();
+                    loop {
+                        let finished = key.rw(|tx| {
+                            let snap_a = a.get(tx, Default::default())?;
+                            let snap_b = b.get(tx, Default::default())?;
+                            if snap_a != snap_b {
+                                a.set(tx, snap_b)?;
+                            }
+                            Ok(snap_a == ITER)
+                        });
+                        if finished {
+                            break;
+                        }
+                    }
+                });
+                // competing parked threads
+                for _ in 0..16 {
+                    // this thread waits for a == b
+                    s.spawn(|_| {
+                        let key = thread_key::get();
+                        loop {
+                            let finished = key.rw(|tx| {
+                                let snap_a = a.get(tx, Default::default())?;
+                                let snap_b = b.get(tx, Default::default())?;
+                                if snap_a != snap_b {
+                                    Err(Status::AWAIT_RETRY)
+                                } else {
+                                    Ok(snap_a == ITER)
+                                }
+                            });
+                            if finished {
+                                break;
+                            }
+                        }
+                    });
+                }
+            })
+            .unwrap()
+        }
+    }
+}

--- a/tests/unpark.rs
+++ b/tests/unpark.rs
@@ -2,6 +2,12 @@ mod unpark {
     use crossbeam_utils::thread;
     use swym::{tcell::TCell, thread_key, tx::Status};
 
+    #[test]
+    fn empty_tx() {
+        let key = thread_key::get();
+        let () = key.rw(|_| Err(Status::AWAIT_RETRY));
+    }
+
     // This test attempts to create a situation where a thread can fail to park on `a` & `b`.
     // Specifically, parking validation fails on `b`. This causes the thread to try to clear the
     // unpark bit it might have just set on `a`. This is incorrect if there is another thread parked
@@ -73,5 +79,6 @@ mod unpark {
             })
             .unwrap()
         }
+        swym::stats::print_stats()
     }
 }

--- a/tests/unpark.rs
+++ b/tests/unpark.rs
@@ -13,7 +13,7 @@ mod unpark {
 
         // if we haven't completed in a reasonable amount of time, abort, failing the test
         std::thread::spawn(|| {
-            std::thread::sleep(std::time::Duration::from_secs(10));
+            std::thread::sleep(std::time::Duration::from_secs(30));
             std::process::abort();
         });
 


### PR DESCRIPTION
**This PR introduces haskell style blocking retries.**

Below is a list of pieces required to get this working, and some rambly thoughts.

- [x] When a user explicitly asks for the transaction to be retried, `swym` will now park the thread.
- [x] When any of the `TCell`'s in the read set are modified, the thread will be unparked, and the transaction retried.
- [x] Requesting a retry with an empty read set is a user error, causing a panic in debug. In release it parks the thread forever.
- [x] Should read only transactions support **retry**? Currently they don't have a read log
    * Punting on that decision. read only transactions cannot retry at the moment (typechecked)
- [x] Some transactions or sub call graphs of transactions will never request a retry, make sure they aren't paying penalty for the extra `Error` type.
    - [x] Have an error type that can _only_ be `Conflict`, but with an `into` for the larger error type
    - [x] ~Allow transaction closures to return the new error type (run_rw/read call into on it)~. This is not ergonomic. Breaks type inference.
    - [x] Update get/set to return the new error type.
- [x] While parked, the thread is unpinned, allowing garbage collection on it's read/write set (should be safe - all unparking requires is version information)
- [x] Update documentation of `RETRY`, `Ordering::Read`, and anything else relevant.
- [x] Collect data on parking when the `stats` feature is enabled.
- [x] Only call into unpark when necessary.
    * Idea: Reserve another bit in `EpochLock` for the `UNPARK_BIT`. When this bit is set, no threads are waiting on that TCell. When that bit is cleared, a thread is waiting on that TCell. While locking the write set, we can simultaneously check to see if unparking is necessary. ~The tricky bit :P is knowing when to set the `UNPARK_BIT` again.~ Publishing always sets the `UNPARK_BIT` as the publishing thread will always unpark _all_ the threads waiting on a modification to a particular `TCell`.
- [x] Undoing a failed park currently resets all `UNPARK_BIT`s in the tx logs. This can cause preexisting parked threads to never be unparked.

Ultimately, this feature looks like it'll be much easier to implement efficiently than expected. `parking_lot_core` is doing all the heavy lifting.

Update: Renaming `RETRY` to `AWAIT_RETRY`