### PR TITLE
Bloom filter fallback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ stats = []
 [dependencies]
 cfg-if = "0.1.9"
 crossbeam-utils = "0.6.5"
+fxhash = "0.2.1"
 lazy_static = "1.3.0"
 lock_api = "0.2.0"
 parking_lot = "0.8.0"

--- a/benches/single_threaded_scaling.rs
+++ b/benches/single_threaded_scaling.rs
@@ -75,9 +75,10 @@ mod single_threaded_scaling {
         write_008, lock_write_008, atomic_write_008, 8;
         write_016, lock_write_016, atomic_write_016, 16;
         write_032, lock_write_032, atomic_write_032, 32;
-        write_064, lock_write_064, atomic_write_064, 64;
+        write_063, lock_write_063, atomic_write_063, 63;
 
         // start to hit bloom filter failure here
+        write_064, lock_write_064, atomic_write_064, 64;
         write_065, lock_write_065, atomic_write_065, 65;
         write_066, lock_write_066, atomic_write_066, 66;
         write_067, lock_write_067, atomic_write_067, 67;

--- a/benches/single_threaded_scaling.rs
+++ b/benches/single_threaded_scaling.rs
@@ -11,7 +11,7 @@ mod single_threaded_scaling {
     use swym::{tcell::TCell, thread_key, tx::Ordering};
     use test::Bencher;
 
-    /// this demonstrates issues with the writelog
+    /// This should reveal performance cliffs and regressions in the write log.
     macro_rules! write_count {
         ($name:ident, $lock_name:ident, $atomic_name:ident, $amount:expr) => {
             #[bench]
@@ -84,7 +84,7 @@ mod single_threaded_scaling {
         write_068, lock_write_068, atomic_write_068, 68;
 
         write_128, lock_write_128, atomic_write_128, 128;
-
-        write_256, lock_write_256, atomic_write_256, 256
+        write_256, lock_write_256, atomic_write_256, 256;
+        write_512, lock_write_512, atomic_write_512, 512
     }
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -7,10 +7,12 @@ pub mod alloc;
 #[macro_use]
 pub mod phoenix_tls;
 
-pub mod commit;
+pub mod bloom;
+mod commit;
+mod gc;
+mod parking;
+
 pub mod epoch;
-pub mod gc;
-pub mod parking;
 pub mod read_log;
 pub mod tcell_erased;
 pub mod thread;

--- a/src/internal/bloom.rs
+++ b/src/internal/bloom.rs
@@ -11,6 +11,7 @@ use core::{
     num::NonZeroUsize,
 };
 use fxhash::FxHashMap;
+use std::collections::hash_map::Entry;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum Contained {
@@ -128,17 +129,16 @@ impl<'tcell, K> Bloom<'tcell, K> {
         }
     }
 
-    #[inline(never)]
-    #[cold]
-    pub fn insert_overflow(&self, key: &'tcell K, index: usize) -> bool {
-        debug_assert!(self.has_overflowed());
-        self.overflow().insert(key, index).is_some()
-    }
-
     #[inline]
     pub fn overflow_get(&self, key: &K) -> Option<usize> {
         debug_assert!(self.has_overflowed());
         self.overflow().get(&(key as _)).cloned()
+    }
+
+    #[inline]
+    pub fn overflow_entry(&self, key: &K) -> Entry<'_, *const K, usize> {
+        debug_assert!(self.has_overflowed());
+        self.overflow().entry(key as _)
     }
 }
 

--- a/src/internal/bloom.rs
+++ b/src/internal/bloom.rs
@@ -1,0 +1,167 @@
+//! A simple 64bit bloom filter that falls back to an actual HashMap.
+//!
+//!
+//!
+//! Potentially relevant paper: http://www.eecg.toronto.edu/~steffan/papers/jeffrey_spaa11.pdf
+
+use core::{
+    cell::{Cell, UnsafeCell},
+    marker::PhantomData,
+    mem,
+    num::NonZeroUsize,
+};
+use fxhash::FxHashMap;
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum Contained {
+    No,
+    Maybe,
+}
+
+#[derive(Copy, Clone, Debug)]
+enum Filter {
+    Inline(usize),
+    Overflow,
+}
+
+#[derive(Debug)]
+pub struct Bloom<'tcell, K> {
+    filter:   Cell<Filter>,
+    overflow: UnsafeCell<FxHashMap<*const K, usize>>,
+    phantom:  PhantomData<&'tcell K>,
+}
+
+impl<'tcell, K> Bloom<'tcell, K> {
+    #[inline]
+    pub fn new() -> Self {
+        Bloom {
+            filter:   Cell::new(Filter::Inline(0)),
+            overflow: Default::default(),
+            phantom:  PhantomData,
+        }
+    }
+
+    fn overflow(&self) -> &mut FxHashMap<*const K, usize> {
+        unsafe { &mut *self.overflow.get() }
+    }
+
+    #[inline]
+    fn has_overflowed(&self) -> bool {
+        match self.filter.get() {
+            Filter::Overflow => true,
+            Filter::Inline(_) => false,
+        }
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        match *self.filter.get_mut() {
+            Filter::Overflow => self.overflow().clear(),
+            Filter::Inline(_) => {}
+        }
+        *self.filter.get_mut() = Filter::Inline(0);
+        debug_assert!(
+            self.overflow().is_empty(),
+            "`clear` failed to empty the container"
+        );
+        debug_assert!(self.is_empty(), "`clear` failed to empty the container");
+        debug_assert!(
+            !self.has_overflowed(),
+            "`clear` failed to reset to `Inline` storage"
+        );
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        match self.filter.get() {
+            Filter::Inline(filter) => filter == 0,
+            Filter::Overflow => self.overflow().is_empty(),
+        }
+    }
+
+    #[inline]
+    pub fn to_overflow(&self, offsets: impl Iterator<Item = (&'tcell K, usize)>) {
+        match self.filter.get() {
+            Filter::Overflow => {}
+            Filter::Inline(_) => self.run_overflow(offsets),
+        }
+    }
+
+    #[inline(never)]
+    #[cold]
+    fn run_overflow(&self, offsets: impl Iterator<Item = (&'tcell K, usize)>) {
+        self.filter.set(Filter::Overflow);
+        let overflow = self.overflow();
+        overflow.extend(offsets.map(|(k, v)| (k as *const K, v)));
+    }
+
+    #[inline]
+    pub fn contained(&self, key: &K) -> Contained {
+        match self.filter.get() {
+            Filter::Inline(filter) => {
+                let bit = bloom_bit(key);
+
+                if unlikely!(filter & bit.0.get() != 0) {
+                    Contained::Maybe
+                } else {
+                    Contained::No
+                }
+            }
+            Filter::Overflow => Contained::Maybe,
+        }
+    }
+
+    #[inline]
+    pub fn insert_inline(&self, key: &'tcell K) -> Contained {
+        match self.filter.get() {
+            Filter::Inline(filter) => {
+                let bit = bloom_bit(key);
+
+                if unlikely!(filter & bit.0.get() != 0) {
+                    Contained::Maybe
+                } else {
+                    self.filter.set(Filter::Inline(filter | bit.0.get()));
+                    Contained::No
+                }
+            }
+            Filter::Overflow => Contained::Maybe,
+        }
+    }
+
+    #[inline(never)]
+    #[cold]
+    pub fn insert_overflow(&self, key: &'tcell K, index: usize) -> bool {
+        debug_assert!(self.has_overflowed());
+        self.overflow().insert(key, index).is_some()
+    }
+
+    #[inline]
+    pub fn overflow_get(&self, key: &K) -> Option<usize> {
+        debug_assert!(self.has_overflowed());
+        self.overflow().get(&(key as _)).cloned()
+    }
+}
+
+#[inline]
+const fn calc_shift<T>() -> usize {
+    (mem::align_of::<T>() > 1) as usize
+        + (mem::align_of::<T>() > 2) as usize
+        + (mem::align_of::<T>() > 4) as usize
+        + (mem::align_of::<T>() > 8) as usize
+        + 1 // In practice this +1 results in less failures, however it's not "correct". Any TCell with a
+            // meaningful value happens to have a minimum size of mem::size_of::<usize>() * 2 which might
+            // explain why the +1 is helpful for certain workloads.
+}
+
+#[inline]
+fn bloom_bit<T>(value: *const T) -> BloomBit {
+    let shift = calc_shift::<T>();
+    let raw_hash: usize = value as usize >> shift;
+    let result = 1 << (raw_hash & (mem::size_of::<NonZeroUsize>() * 8 - 1));
+    debug_assert!(result > 0, "bloom_hash should not return 0");
+    let hash = unsafe { NonZeroUsize::new_unchecked(result) };
+    BloomBit(hash)
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+struct BloomBit(NonZeroUsize);

--- a/src/rw.rs
+++ b/src/rw.rs
@@ -10,9 +10,10 @@
 use crate::{
     internal::{
         alloc::dyn_vec::{self, DynElemMut},
+        bloom::Contained,
         tcell_erased::TCellErased,
         thread::{PinMutRef, PinRw},
-        write_log::{bloom_hash, Contained, Entry, WriteEntry, WriteEntryImpl},
+        write_log::{Entry, WriteEntry, WriteEntryImpl},
     },
     stats,
     tcell::{Ref, TCell},
@@ -90,7 +91,7 @@ impl<'tx, 'tcell> RwTxImpl<'tx, 'tcell> {
     fn borrow_impl<T>(mut self, tcell: &'tcell TCell<T>) -> Result<Ref<'tx, T>, Error> {
         let logs = self.logs();
         if likely!(!logs.read_log.next_push_allocates())
-            && likely!(logs.write_log.contained(bloom_hash(&tcell.erased)) == Contained::No)
+            && likely!(logs.write_log.contained(&tcell.erased) == Contained::No)
         {
             unsafe {
                 let value = Ref::new(tcell.optimistic_read_acquire());
@@ -108,7 +109,7 @@ impl<'tx, 'tcell> RwTxImpl<'tx, 'tcell> {
     #[cold]
     fn borrow_unlogged_slow<T>(self, tcell: &TCell<T>) -> Result<Ref<'tx, T>, Error> {
         let logs = self.logs();
-        let found = logs.write_log.find(&tcell.erased);
+        let found = logs.write_log.find_skip_filter(&tcell.erased);
         unsafe {
             match found {
                 None => {
@@ -132,7 +133,7 @@ impl<'tx, 'tcell> RwTxImpl<'tx, 'tcell> {
     #[inline]
     fn borrow_unlogged_impl<T>(self, tcell: &'tcell TCell<T>) -> Result<Ref<'tx, T>, Error> {
         let logs = self.logs();
-        if likely!(logs.write_log.contained(bloom_hash(&tcell.erased)) == Contained::No) {
+        if likely!(logs.write_log.contained(&tcell.erased) == Contained::No) {
             unsafe {
                 let value = Ref::new(tcell.optimistic_read_acquire());
                 if likely!(self.rw_valid(&tcell.erased)) {
@@ -152,20 +153,25 @@ impl<'tx, 'tcell> RwTxImpl<'tx, 'tcell> {
     ) -> Result<(), SetError<T>> {
         unsafe {
             match self.logs_mut().write_log.entry(&tcell.erased) {
-                Entry::Vacant { write_log: _, hash } => {
+                Entry::Vacant => {
                     if likely!(self.rw_valid(&tcell.erased)) {
                         let logs = self.logs_mut();
-                        logs.write_log.record(&tcell.erased, value, hash);
+                        let replaced = logs.write_log.record_update(&tcell.erased, value);
+                        debug_assert!(!replaced);
                         if mem::needs_drop::<T>() {
                             logs.garbage.dispose(tcell.optimistic_read_relaxed())
                         }
                         return Ok(());
                     }
                 }
-                Entry::Occupied { mut entry, hash } => {
+                Entry::Occupied { mut entry } => {
                     if V::REQUEST_TCELL_LIFETIME {
                         entry.deactivate();
-                        self.logs_mut().write_log.record(&tcell.erased, value, hash);
+                        let replaced = self
+                            .logs_mut()
+                            .write_log
+                            .record_update(&tcell.erased, value);
+                        debug_assert!(replaced);
                     } else {
                         let new_entry = WriteEntryImpl::new(&tcell.erased, value);
                         let new_vtable = dyn_vec::vtable::<dyn WriteEntry + 'tcell>(&new_entry);
@@ -191,16 +197,14 @@ impl<'tx, 'tcell> RwTxImpl<'tx, 'tcell> {
         value: V,
     ) -> Result<(), SetError<T>> {
         let logs = self.logs();
-        let hash = bloom_hash(&tcell.erased);
-
         if likely!(!logs.write_log.next_push_allocates::<V>())
             && (!mem::needs_drop::<T>() || likely!(!logs.garbage.next_dispose_allocates::<T>()))
-            && likely!(logs.write_log.contained(hash) == Contained::No)
+            && likely!(logs.write_log.contained_set(&tcell.erased) == Contained::No)
             && likely!(self.rw_valid(&tcell.erased))
         {
             let logs = self.logs_mut();
             unsafe {
-                logs.write_log.record_unchecked(&tcell.erased, value, hash);
+                logs.write_log.record_unchecked(&tcell.erased, value);
                 if mem::needs_drop::<T>() {
                     logs.garbage
                         .dispose_unchecked(tcell.optimistic_read_relaxed())

--- a/tests/unpark.rs
+++ b/tests/unpark.rs
@@ -17,7 +17,7 @@ mod unpark {
     #[test]
     fn park_failure() {
         const ITER: usize = 1_000;
-        const TRIES: usize = 100;
+        const TRIES: usize = 50;
 
         // if we haven't completed in a reasonable amount of time, abort, failing the test
         std::thread::spawn(|| {


### PR DESCRIPTION
Previously, when the bloom filter got too full (large transactions), reads and writes started hitting O(n^2) lookups, tanking performance.

Now on the first bloom filter failure, the bloom filter "rolls over" into an actual `FxHashMap`, which has more reasonable linear growth.