### PR TITLE
starvation freedom - and use criterion for rbtree benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ crossbeam-utils = "0.6.5"
 fxhash = "0.2.1"
 lazy_static = "1.3.0"
 lock_api = "0.2.0"
-num_cpus = "1.10.1"
 parking_lot = "0.8.0"
 parking_lot_core = "0.5.0"
 swym-htm = { path = "./swym-htm", version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ crossbeam-utils = "0.6.5"
 fxhash = "0.2.1"
 lazy_static = "1.3.0"
 lock_api = "0.2.0"
+num_cpus = "1.10.1"
 parking_lot = "0.8.0"
 parking_lot_core = "0.5.0"
 swym-htm = { path = "./swym-htm", version = "0.1.0" }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+macro_rules! stats {
+    ($($(#[$attr:meta])* $names:ident: $kinds:tt @ $env_var:ident),* $(,)*) => {
+        concat!($("cargo:rerun-if-env-changed=", "SWYM_", stringify!($env_var),"\n"),*)
+    };
+}
+
+fn main() {
+    println!(include!("./src/stats_list.rs"));
+}

--- a/ci/rbtree.sh
+++ b/ci/rbtree.sh
@@ -30,43 +30,11 @@ cargo check --features debug-alloc,nightly,stats,$RTM --benches --bins --example
 # run tests
 ./x.py test
 RUST_TEST_THREADS=1 cargo test --features stats,nightly,$RTM --lib --tests
-RUST_TEST_THREADS=1 RUSTFLAGS="${RUSTFLAGS} ${ASAN_FLAG}" \
-    time cargo test \
-        --features debug-alloc,stats,$RTM
+
+# TODO: address sanitizer doesn't work with criterion?
+# RUSTFLAGS="${RUSTFLAGS} ${ASAN_FLAG}"
+RUST_TEST_THREADS=1 \
+    time cargo test --features debug-alloc,stats,$RTM
 
 # benchmarks
-./x.py bench insert:: --features nightly,$RTM 
-
-# these benchmarks are run one at a time due to high memory usage
-./x.py bench --features nightly,$RTM rbtree::contains_key_01
-./x.py bench --features nightly,$RTM rbtree::contains_key_02
-./x.py bench --features nightly,$RTM rbtree::contains_key_03
-./x.py bench --features nightly,$RTM rbtree::contains_key_04
-./x.py bench --features nightly,$RTM rbtree::contains_key_05
-./x.py bench --features nightly,$RTM rbtree::contains_key_06
-./x.py bench --features nightly,$RTM rbtree::contains_key_07
-./x.py bench --features nightly,$RTM rbtree::contains_key_08
-./x.py bench --features nightly,$RTM rbtree::entry_01
-./x.py bench --features nightly,$RTM rbtree::entry_02
-./x.py bench --features nightly,$RTM rbtree::entry_03
-./x.py bench --features nightly,$RTM rbtree::entry_04
-./x.py bench --features nightly,$RTM rbtree::entry_05
-./x.py bench --features nightly,$RTM rbtree::entry_06
-./x.py bench --features nightly,$RTM rbtree::entry_07
-./x.py bench --features nightly,$RTM rbtree::entry_08
-./x.py bench --features nightly,$RTM rbtree::get_01
-./x.py bench --features nightly,$RTM rbtree::get_02
-./x.py bench --features nightly,$RTM rbtree::get_03
-./x.py bench --features nightly,$RTM rbtree::get_04
-./x.py bench --features nightly,$RTM rbtree::get_05
-./x.py bench --features nightly,$RTM rbtree::get_06
-./x.py bench --features nightly,$RTM rbtree::get_07
-./x.py bench --features nightly,$RTM rbtree::get_08
-./x.py bench --features nightly,$RTM rbtree::insert_01
-./x.py bench --features nightly,$RTM rbtree::insert_02
-./x.py bench --features nightly,$RTM rbtree::insert_03
-./x.py bench --features nightly,$RTM rbtree::insert_04
-./x.py bench --features nightly,$RTM rbtree::insert_05
-./x.py bench --features nightly,$RTM rbtree::insert_06
-./x.py bench --features nightly,$RTM rbtree::insert_07
-./x.py bench --features nightly,$RTM rbtree::insert_08
+./x.py bench --features nightly,$RTM

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -11,6 +11,7 @@ pub mod bloom;
 mod commit;
 mod gc;
 mod parking;
+mod starvation;
 
 pub mod epoch;
 pub mod read_log;

--- a/src/internal/alloc/fvec.rs
+++ b/src/internal/alloc/fvec.rs
@@ -1,6 +1,6 @@
 use core::ops::{Deref, DerefMut};
 
-const START_SIZE: usize = 1024;
+const START_SIZE: usize = 0;
 
 #[derive(Debug)]
 pub struct FVec<T> {

--- a/src/internal/commit.rs
+++ b/src/internal/commit.rs
@@ -148,7 +148,7 @@ impl<'tx, 'tcell> PinRw<'tx, 'tcell> {
                 self.commit_soft()
             }
             Err(BoundedHtxErr::AbortOrConflict) => {
-                stats::htm_conflicts(retry_count as _);
+                stats::htm_abort(retry_count as _);
                 false
             }
         }

--- a/src/internal/epoch.rs
+++ b/src/internal/epoch.rs
@@ -52,7 +52,7 @@ const FIRST: Storage = TICK_SIZE + UNPARK_BIT;
 /// The smallest difference between points on the EpochClock.
 ///
 /// Two is used because the first bit of EpochLock is reserved as the UNPARK_BIT
-const TICK_SIZE: Storage = 1 << 1;
+pub const TICK_SIZE: Storage = 1 << 1;
 
 /// The least significant bit is set when _no_ threads are parked waiting for modifications to an
 /// EpochLock.
@@ -121,6 +121,11 @@ impl QuiesceEpoch {
             "creating a locked `QuieseEpoch` is a logic error"
         );
         NonZeroStorage::new(epoch).map(QuiesceEpoch)
+    }
+
+    #[inline]
+    pub fn get(self) -> NonZeroStorage {
+        self.0
     }
 
     /// Returns the maximum value that a QuiesceEpoch can hold. This is useful for finding the

--- a/src/internal/epoch.rs
+++ b/src/internal/epoch.rs
@@ -492,6 +492,7 @@ impl ThreadEpoch {
 
 /// A monotonically increasing clock.
 #[derive(Debug)]
+#[repr(align(64))]
 pub struct EpochClock(HtmStorage);
 
 /// The world clock. The source of truth, and synchronization for swym. Every write transaction

--- a/src/internal/optim.rs
+++ b/src/internal/optim.rs
@@ -34,6 +34,7 @@ pub fn _likely(b: bool) -> bool {
     b
 }
 
+#[cold]
 pub fn _abort() -> ! {
     std::process::abort();
 }

--- a/src/internal/read_log.rs
+++ b/src/internal/read_log.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use swym_htm::HardwareTx;
 
-const READ_CAPACITY: usize = 1024;
+const READ_CAPACITY: usize = 0;
 
 #[derive(Debug)]
 pub struct ReadLog<'tcell> {

--- a/src/internal/starvation.rs
+++ b/src/internal/starvation.rs
@@ -17,13 +17,13 @@ use crate::{
 };
 use core::{
     cell::Cell,
-    num::NonZeroU32,
+    num::{NonZeroU32, NonZeroUsize},
     sync::atomic::{self, AtomicUsize, Ordering::Relaxed},
 };
 use parking_lot_core::{self, FilterOp, ParkResult, ParkToken, UnparkResult, UnparkToken};
 use std::thread;
 
-const NO_STARVERS_EPOCH: usize = 0;
+const NO_STARVERS: usize = 0;
 const SPIN_LIMIT: u32 = 6;
 const YIELD_LIMIT: u32 = 10;
 
@@ -34,80 +34,85 @@ const YIELD_LIMIT: u32 = 10;
 const MAX_ELAPSED_EPOCHS: usize = 64 * TICK_SIZE;
 
 static STARVATION: Starvation = Starvation {
-    blocked_epoch: AtomicUsize::new(NO_STARVERS_EPOCH),
+    starved_token: AtomicUsize::new(NO_STARVERS),
 };
 
 /// `Starvation` only uses `Relaxed` memory ` ordering.
 struct Starvation {
-    blocked_epoch: AtomicUsize,
+    starved_token: AtomicUsize,
 }
 
 impl Starvation {
     #[inline]
-    fn starve_lock(&self, epoch: QuiesceEpoch) {
+    fn starve_lock(&self, token: NonZeroUsize) {
         if self
-            .blocked_epoch
-            .compare_exchange_weak(NO_STARVERS_EPOCH, epoch.get().get(), Relaxed, Relaxed)
+            .starved_token
+            .compare_exchange_weak(NO_STARVERS, token.get(), Relaxed, Relaxed)
             .is_err()
         {
-            drop(self.starve_lock_slow(epoch));
+            drop(self.starve_lock_slow(token));
         }
     }
 
     #[inline]
-    fn starve_unlock<F: FnOnce()>(&self, non_inlined_work: F) {
+    fn starve_unlock<F: FnOnce(), G: FnMut(NonZeroUsize) -> bool, U: FnOnce(NonZeroUsize)>(
+        &self,
+        non_inlined_work: F,
+        should_upgrade: G,
+        upgrade: U,
+    ) {
         // If a thread is starving, unparking is usually gonna happen.
         //
         // There's also not much to gain from a fast path as starvation handling is already in a
         // deeply slow path.
-        self.starve_unlock_slow(non_inlined_work);
+        self.starve_unlock_slow(non_inlined_work, should_upgrade, upgrade);
     }
 
     #[inline]
-    fn wait_for_starvers<F: FnMut() -> Option<QuiesceEpoch>>(&self, should_upgrade: F) {
-        let blocked_epoch = self.blocked_epoch.load(Relaxed);
-        if unlikely!(blocked_epoch != NO_STARVERS_EPOCH) {
-            self.wait_for_starvers_slow(should_upgrade)
+    fn wait_for_starvers(&self, token: NonZeroUsize) {
+        let starved_token = self.starved_token.load(Relaxed);
+        if unlikely!(starved_token != NO_STARVERS) {
+            self.wait_for_starvers_slow(token)
         }
     }
 
     #[cold]
     #[inline(never)]
-    fn starve_lock_slow(&self, epoch: QuiesceEpoch) {
-        let mut blocked_epoch = self.blocked_epoch.load(Relaxed);
+    fn starve_lock_slow(&self, token: NonZeroUsize) {
+        let mut starved_token = self.starved_token.load(Relaxed);
         loop {
-            if blocked_epoch == NO_STARVERS_EPOCH {
-                match self.blocked_epoch.compare_exchange_weak(
-                    NO_STARVERS_EPOCH,
-                    epoch.get().get(),
+            if starved_token == NO_STARVERS {
+                match self.starved_token.compare_exchange_weak(
+                    NO_STARVERS,
+                    token.get(),
                     Relaxed,
                     Relaxed,
                 ) {
                     Ok(_) => return,
-                    Err(x) => blocked_epoch = x,
+                    Err(x) => starved_token = x,
                 }
                 continue;
             }
 
             // Park our thread until we are woken up by an unlock
             let addr = self as *const _ as usize;
-            let validate = || self.blocked_epoch.load(Relaxed) != NO_STARVERS_EPOCH;
+            let validate = || self.starved_token.load(Relaxed) != NO_STARVERS;
             let before_sleep = || {};
             let timed_out = |_, _| {};
-            let park_token = ParkToken(epoch.get().get());
+            let park_token = ParkToken(token.get());
             match unsafe {
                 parking_lot_core::park(addr, validate, before_sleep, timed_out, park_token, None)
             } {
-                ParkResult::Unparked(UnparkToken(wakeup_epoch)) => {
+                ParkResult::Unparked(UnparkToken(wakeup_token)) => {
                     debug_assert!(
-                        wakeup_epoch != NO_STARVERS_EPOCH,
+                        wakeup_token != NO_STARVERS,
                         "unfairly unparking a starving thread"
                     );
-                    if wakeup_epoch == epoch.get().get() {
+                    if wakeup_token == token.get() {
                         debug_assert_eq!(
-                            wakeup_epoch,
-                            self.blocked_epoch.load(Relaxed),
-                            "improperly set the blocked_epoch before handing off starvation \
+                            wakeup_token,
+                            self.starved_token.load(Relaxed),
+                            "improperly set the starved_token before handing off starvation \
                              control"
                         );
                         return;
@@ -116,83 +121,95 @@ impl Starvation {
                 ParkResult::Invalid => {}
                 ParkResult::TimedOut => debug_assert!(false),
             }
-            blocked_epoch = self.blocked_epoch.load(Relaxed);
+            starved_token = self.starved_token.load(Relaxed);
         }
     }
 
     #[cold]
     #[inline(never)]
-    fn wait_for_starvers_slow<F: FnMut() -> Option<QuiesceEpoch>>(&self, mut should_upgrade: F) {
-        let mut blocked_epoch = self.blocked_epoch.load(Relaxed);
+    fn wait_for_starvers_slow(&self, token: NonZeroUsize) {
+        let mut starved_token = self.starved_token.load(Relaxed);
         loop {
-            if blocked_epoch == NO_STARVERS_EPOCH {
+            if starved_token == NO_STARVERS {
                 return;
             }
 
             // Park our thread until we are woken up by an unlock
             let addr = self as *const _ as usize;
-            let validate = || self.blocked_epoch.load(Relaxed) != NO_STARVERS_EPOCH;
+            let validate = || self.starved_token.load(Relaxed) != NO_STARVERS;
             let before_sleep = || {};
             let timed_out = |_, _| {};
-            if let Some(epoch) = should_upgrade() {
-                return self.starve_lock_slow(epoch);
-            }
             match unsafe {
                 parking_lot_core::park(
                     addr,
                     validate,
                     before_sleep,
                     timed_out,
-                    ParkToken(NO_STARVERS_EPOCH),
+                    ParkToken(token.get()),
                     None,
                 )
             } {
-                ParkResult::Unparked(UnparkToken(NO_STARVERS_EPOCH)) => {
+                ParkResult::Unparked(UnparkToken(NO_STARVERS)) => {
                     return;
                 }
-                ParkResult::Unparked(_) => {}
+                ParkResult::Unparked(UnparkToken(wakeup_token)) => {
+                    if wakeup_token == token.get() {
+                        // this thread has been upgraded to a starver
+                        debug_assert_eq!(
+                            wakeup_token,
+                            self.starved_token.load(Relaxed),
+                            "improperly set the starved_token before handing off starvation \
+                             control"
+                        );
+                    }
+                    return;
+                }
                 ParkResult::Invalid => {}
                 ParkResult::TimedOut => debug_assert!(false),
             }
-            blocked_epoch = self.blocked_epoch.load(Relaxed);
+            starved_token = self.starved_token.load(Relaxed);
         }
     }
 
     #[cold]
     #[inline(never)]
-    fn starve_unlock_slow<F: FnOnce()>(&self, non_inlined_work: F) {
+    fn starve_unlock_slow<F: FnOnce(), G: FnMut(NonZeroUsize) -> bool, U: FnOnce(NonZeroUsize)>(
+        &self,
+        non_inlined_work: F,
+        mut should_upgrade: G,
+        upgrade: U,
+    ) {
         non_inlined_work();
 
         let addr = self as *const _ as usize;
-        let starve_epoch = Cell::new(NO_STARVERS_EPOCH);
-        let starve_epoch = &starve_epoch;
+        let next_starved_token = Cell::new(NO_STARVERS);
+        let next_starved_token = &next_starved_token;
 
         // We don't know what thread we wish to unpark until we finish filtering. This means that
         // threads will sometimes be unparked without the possibility of making progress.
-        let filter = |token: ParkToken| {
-            let epoch = starve_epoch.get();
-            if epoch == NO_STARVERS_EPOCH {
-                starve_epoch.set(token.0);
-                FilterOp::Unpark
-            } else if token.0 == NO_STARVERS_EPOCH {
-                FilterOp::Skip
-            } else if token.0 < epoch {
-                starve_epoch.set(token.0);
+        let filter = move |token: ParkToken| {
+            debug_assert!(token.0 != NO_STARVERS, "invalid ParkToken detected");
+            let next_starved = next_starved_token.get();
+            if next_starved == NO_STARVERS {
+                if should_upgrade(unsafe { NonZeroUsize::new_unchecked(token.0) }) {
+                    next_starved_token.set(token.0);
+                }
                 FilterOp::Unpark
             } else {
                 FilterOp::Skip
             }
         };
         let callback = |unpark_result: UnparkResult| {
-            debug_assert_ne!(self.blocked_epoch.load(Relaxed), NO_STARVERS_EPOCH);
-            let epoch = starve_epoch.get();
-            self.blocked_epoch.store(epoch, Relaxed);
-            debug_assert!(epoch == NO_STARVERS_EPOCH || unpark_result.unparked_threads > 0);
-            UnparkToken(epoch)
+            debug_assert_ne!(self.starved_token.load(Relaxed), NO_STARVERS);
+            let next_starved = next_starved_token.get();
+            self.starved_token.store(next_starved, Relaxed);
+            drop(NonZeroUsize::new(next_starved).map(|this| upgrade(this)));
+            debug_assert!(next_starved == NO_STARVERS || unpark_result.unparked_threads > 0);
+            UnparkToken(next_starved)
         };
 
         let result = unsafe { parking_lot_core::unpark_filter(addr, filter, callback) };
-        if starve_epoch.get() != NO_STARVERS_EPOCH {
+        if next_starved_token.get() != NO_STARVERS {
             stats::starvation_handoff();
         }
         stats::blocked_by_starvation(result.unparked_threads)
@@ -208,6 +225,34 @@ enum ProgressImpl {
     Starving,
 }
 
+impl ProgressImpl {
+    #[inline]
+    fn new() -> Self {
+        ProgressImpl::NotStarving {
+            first_failed_epoch: None,
+            backoff:            unsafe { NonZeroU32::new_unchecked(1) },
+        }
+    }
+
+    #[inline]
+    fn should_starve(&self) -> bool {
+        match self {
+            ProgressImpl::NotStarving {
+                first_failed_epoch: Some(_),
+                backoff,
+            } => backoff.get() >= YIELD_LIMIT,
+            ProgressImpl::NotStarving {
+                first_failed_epoch: None,
+                ..
+            } => false,
+            ProgressImpl::Starving => {
+                debug_assert!(false);
+                false
+            }
+        }
+    }
+}
+
 pub struct Progress {
     inner: Cell<ProgressImpl>,
 }
@@ -219,7 +264,7 @@ impl Drop for Progress {
             ProgressImpl::NotStarving {
                 first_failed_epoch: None,
                 backoff,
-            } if backoff.get() == 0 => {}
+            } if backoff.get() == 1 => {}
             _ => panic!("`Progress` dropped without having made progress"),
         }
     }
@@ -229,10 +274,7 @@ impl Progress {
     #[inline]
     pub fn new() -> Self {
         Progress {
-            inner: Cell::new(ProgressImpl::NotStarving {
-                first_failed_epoch: None,
-                backoff:            NonZeroU32::new(1).unwrap(),
-            }),
+            inner: Cell::new(ProgressImpl::new()),
         }
     }
 
@@ -249,6 +291,8 @@ impl Progress {
                 if backoff.get() <= SPIN_LIMIT {
                     let now = EPOCH_CLOCK.now().unwrap_or_else(|| abort!());
                     if now.get().get() - epoch.get().get() >= MAX_ELAPSED_EPOCHS {
+                        // long transaction detected, `spin_loop_hint` is probably a bad backoff
+                        // strategy.
                         self.inner.set(ProgressImpl::NotStarving {
                             first_failed_epoch: Some(epoch),
                             backoff:            unsafe {
@@ -262,17 +306,15 @@ impl Progress {
                             atomic::spin_loop_hint();
                         }
                     }
-                } else {
+                } else if backoff.get() <= YIELD_LIMIT {
                     thread::yield_now();
-                }
 
-                if backoff.get() <= YIELD_LIMIT {
                     self.inner.set(ProgressImpl::NotStarving {
                         first_failed_epoch: Some(epoch),
                         backoff:            unsafe { NonZeroU32::new_unchecked(backoff.get() + 1) },
                     });
                 } else {
-                    STARVATION.starve_lock(epoch);
+                    STARVATION.starve_lock(self.to_token());
                     self.inner.set(ProgressImpl::Starving)
                 }
             }
@@ -285,9 +327,7 @@ impl Progress {
     #[inline]
     pub fn wait_for_starvers(&self) {
         match self.inner.get() {
-            ProgressImpl::NotStarving { .. } => {
-                STARVATION.wait_for_starvers(|| self.should_upgrade())
-            }
+            ProgressImpl::NotStarving { .. } => STARVATION.wait_for_starvers(self.to_token()),
             ProgressImpl::Starving => {}
         };
     }
@@ -298,56 +338,31 @@ impl Progress {
         match self.inner.get() {
             ProgressImpl::NotStarving { .. } => {}
             ProgressImpl::Starving => {
-                STARVATION.starve_unlock(|| {
-                    self.inner.set(ProgressImpl::NotStarving {
-                        first_failed_epoch: None,
-                        backoff:            NonZeroU32::new(1).unwrap(),
-                    })
-                });
+                STARVATION.starve_unlock(
+                    || self.inner.set(ProgressImpl::new()),
+                    |this| {
+                        unsafe { Self::from_token(this) }
+                            .inner
+                            .get()
+                            .should_starve()
+                    },
+                    |this| {
+                        unsafe { Self::from_token(this) }
+                            .inner
+                            .set(ProgressImpl::Starving)
+                    },
+                );
             }
         };
     }
 
     #[inline]
-    fn should_upgrade(&self) -> Option<QuiesceEpoch> {
-        None
-        // match self.inner.get() {
-        //     ProgressImpl::NotStarving {
-        //         first_failed_epoch: Some(first_failed_epoch),
-        //         backoff,
-        //     } => {
-        //         if backoff.get() <= SPIN_LIMIT {
-        //             let now = EPOCH_CLOCK.now().unwrap_or_else(|| abort!());
-        //             if now.get().get() - first_failed_epoch.get().get() >= MAX_ELAPSED_EPOCHS {
-        //                 self.inner.set(ProgressImpl::NotStarving {
-        //                     first_failed_epoch: Some(first_failed_epoch),
-        //                     backoff:            unsafe {
-        //                         NonZeroU32::new_unchecked(SPIN_LIMIT + 1)
-        //                     },
-        //                 });
-        //                 thread::yield_now();
-        //                 return None;
-        //             } else {
-        //                 for _ in 0..1 << backoff.get() {
-        //                     atomic::spin_loop_hint();
-        //                 }
-        //             }
-        //         } else {
-        //             thread::yield_now();
-        //         }
+    fn to_token(&self) -> NonZeroUsize {
+        unsafe { NonZeroUsize::new_unchecked(self as *const Self as usize) }
+    }
 
-        //         if backoff.get() <= YIELD_LIMIT {
-        //             self.inner.set(ProgressImpl::NotStarving {
-        //                 first_failed_epoch: Some(first_failed_epoch),
-        //                 backoff:            unsafe { NonZeroU32::new_unchecked(backoff.get() + 1)
-        // },             });
-        //         } else {
-        //             epoch = Some(first_failed_epoch);
-        //             self.inner.set(ProgressImpl::Starving);
-        //         }
-        //     }
-        //     _ => {}
-        // };
-        // epoch
+    #[inline]
+    unsafe fn from_token(this: NonZeroUsize) -> &'static Self {
+        &*(this.get() as *const Self)
     }
 }

--- a/src/internal/starvation.rs
+++ b/src/internal/starvation.rs
@@ -1,0 +1,154 @@
+use core::{
+    sync::atomic::{AtomicU8, Ordering},
+    time::Duration,
+};
+use lock_api::{GuardNoSend, RawMutex as RawMutexTrait};
+use parking_lot_core::{self, ParkResult, SpinWait, UnparkResult, UnparkToken, DEFAULT_PARK_TOKEN};
+use std::time::Instant;
+
+type U8 = u8;
+
+const TOKEN_NORMAL: UnparkToken = UnparkToken(0);
+const LOCKED_BIT: U8 = 1;
+const PARKED_BIT: U8 = 2;
+
+#[inline]
+pub fn to_deadline(timeout: Duration) -> Option<Instant> {
+    #[cfg(has_checked_instant)]
+    let deadline = Instant::now().checked_add(timeout);
+    #[cfg(not(has_checked_instant))]
+    let deadline = Some(Instant::now() + timeout);
+
+    deadline
+}
+
+/// Raw mutex type backed by the parking lot.
+pub struct Starvation {
+    state: AtomicU8,
+}
+
+unsafe impl RawMutexTrait for Starvation {
+    const INIT: Starvation = Starvation {
+        state: AtomicU8::new(0),
+    };
+
+    type GuardMarker = GuardNoSend;
+
+    #[inline]
+    fn lock(&self) {
+        if self
+            .state
+            .compare_exchange_weak(0, LOCKED_BIT, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            drop(self.lock_slow());
+        }
+    }
+
+    #[inline]
+    fn try_lock(&self) -> bool {
+        unimplemented!()
+    }
+
+    #[inline]
+    fn unlock(&self) {
+        if self
+            .state
+            .compare_exchange(LOCKED_BIT, 0, Ordering::Release, Ordering::Relaxed)
+            .is_ok()
+        {
+            return;
+        }
+        self.unlock_slow(false);
+    }
+}
+
+impl Starvation {
+    #[inline]
+    pub fn wait_unlocked(&self) {
+        let state = self.state.load(Ordering::Relaxed);
+        if unlikely!(state & LOCKED_BIT != 0) {
+            self.wait_unlocked_slow()
+        }
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn wait_unlocked_slow(&self) {
+        let mut spinwait = SpinWait::new();
+        let mut state = self.state.load(Ordering::Relaxed);
+        loop {
+            // Grab the lock if it isn't locked, even if there is a queue on it
+            if state & LOCKED_BIT == 0 {
+                return;
+            }
+
+            // If there is no queue, try spinning a few times
+            if state & PARKED_BIT == 0 && spinwait.spin() {
+                state = self.state.load(Ordering::Relaxed);
+                continue;
+            }
+
+            // Set the parked bit
+            if state & PARKED_BIT == 0 {
+                if let Err(x) = self.state.compare_exchange_weak(
+                    state,
+                    state | PARKED_BIT,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    state = x;
+                    continue;
+                }
+            }
+
+            // Park our thread until we are woken up by an unlock
+            unsafe {
+                let addr = self as *const _ as usize;
+                let validate = || self.state.load(Ordering::Relaxed) == LOCKED_BIT | PARKED_BIT;
+                let before_sleep = || {};
+                let timed_out = |_, _| unimplemented!();
+                match parking_lot_core::park(
+                    addr,
+                    validate,
+                    before_sleep,
+                    timed_out,
+                    DEFAULT_PARK_TOKEN,
+                    None,
+                ) {
+                    // We were unparked normally, try acquiring the lock again
+                    ParkResult::Unparked(_) => return,
+
+                    // The validation function failed, try locking again
+                    ParkResult::Invalid => (),
+
+                    // Timeout expired
+                    ParkResult::TimedOut => {
+                        debug_assert!(false);
+                        return;
+                    }
+                }
+            }
+
+            // Loop back and try locking again
+            spinwait.reset();
+            state = self.state.load(Ordering::Relaxed);
+        }
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn unlock_slow(&self, force_fair: bool) {
+        unsafe {
+            let addr = self as *const _ as usize;
+            drop(parking_lot_core::unpark_all(addr, TOKEN_NORMAL));
+        }
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn bump_slow(&self) {
+        self.unlock_slow(true);
+        self.lock();
+    }
+}

--- a/src/internal/starvation.rs
+++ b/src/internal/starvation.rs
@@ -1,163 +1,210 @@
-//! `Starvation` is a type used for blocking other threads in order to finish some work that was
-//! unable to be performed speculatively in a finite amount of time.
+//! `Starvation` is a private type used for blocking other threads in order to finish some work that
+//! was unable to be performed speculatively in a finite amount of time. It assumes a fair
+//! scheduler.
+//!
+//! `Progress` contains the logic of when to signal that a thread is starving, and waits for other
+//! threads that are starving.
+//!
+//! http://raiith.iith.ac.in/3530/1/1709.01033.pdf
 //!
 //! Based on RawMutex in parking_lot.
 //!
 //! https://github.com/Amanieu/parking_lot
 
-use crate::stats;
+use crate::{
+    internal::epoch::{QuiesceEpoch, EPOCH_CLOCK, TICK_SIZE},
+    stats,
+};
 use core::{
     cell::Cell,
     num::NonZeroU32,
-    sync::atomic::{self, AtomicBool, Ordering::Relaxed},
+    sync::atomic::{self, AtomicUsize, Ordering::Relaxed},
 };
 use parking_lot_core::{self, FilterOp, ParkResult, ParkToken, UnparkResult, UnparkToken};
 use std::thread;
 
-const NO_STARVERS: UnparkToken = UnparkToken(0);
-const STARVE_HANDOFF: UnparkToken = UnparkToken(1);
-const STARVE_TOKEN: ParkToken = ParkToken(0);
-const WAIT_TOKEN: ParkToken = ParkToken(1);
+const NO_STARVERS_EPOCH: usize = 0;
 const SPIN_LIMIT: u32 = 6;
 const YIELD_LIMIT: u32 = 10;
 
+/// If a thread started a transaction this many epochs ago, the thread is considered to be starving.
+///
+/// Lower values result in more serialization under contention. Higher values result in more wasted
+/// CPU cycles for large transactions.
+const MAX_ELAPSED_EPOCHS: usize = 64 * TICK_SIZE;
+
 static STARVATION: Starvation = Starvation {
-    state: AtomicBool::new(false),
+    blocked_epoch: AtomicUsize::new(NO_STARVERS_EPOCH),
 };
 
-pub struct Starvation {
-    state: AtomicBool,
+/// `Starvation` only uses `Relaxed` memory ` ordering.
+struct Starvation {
+    blocked_epoch: AtomicUsize,
 }
 
 impl Starvation {
     #[inline]
-    pub fn starve_lock(&self) {
+    fn starve_lock(&self, epoch: QuiesceEpoch) {
         if self
-            .state
-            .compare_exchange_weak(false, true, Relaxed, Relaxed)
+            .blocked_epoch
+            .compare_exchange_weak(NO_STARVERS_EPOCH, epoch.get().get(), Relaxed, Relaxed)
             .is_err()
         {
-            drop(self.starve_lock_slow());
+            drop(self.starve_lock_slow(epoch));
         }
     }
 
     #[inline]
-    pub fn starve_unlock(&self) {
+    fn starve_unlock<F: FnOnce()>(&self, non_inlined_work: F) {
         // If a thread is starving, unparking is usually gonna happen.
         //
         // There's also not much to gain from a fast path as starvation handling is already in a
         // deeply slow path.
-        self.starve_unlock_slow();
+        self.starve_unlock_slow(non_inlined_work);
     }
 
     #[inline]
-    pub fn wait_for_starvers(&self) {
-        let state = self.state.load(Relaxed);
-        if unlikely!(state) {
-            self.wait_for_starvers_slow()
+    fn wait_for_starvers<F: FnMut() -> Option<QuiesceEpoch>>(&self, should_upgrade: F) {
+        let blocked_epoch = self.blocked_epoch.load(Relaxed);
+        if unlikely!(blocked_epoch != NO_STARVERS_EPOCH) {
+            self.wait_for_starvers_slow(should_upgrade)
         }
     }
 
     #[cold]
     #[inline(never)]
-    fn starve_lock_slow(&self) {
-        let mut state = self.state.load(Relaxed);
+    fn starve_lock_slow(&self, epoch: QuiesceEpoch) {
+        let mut blocked_epoch = self.blocked_epoch.load(Relaxed);
         loop {
-            if !state {
-                match self
-                    .state
-                    .compare_exchange_weak(false, true, Relaxed, Relaxed)
-                {
+            if blocked_epoch == NO_STARVERS_EPOCH {
+                match self.blocked_epoch.compare_exchange_weak(
+                    NO_STARVERS_EPOCH,
+                    epoch.get().get(),
+                    Relaxed,
+                    Relaxed,
+                ) {
                     Ok(_) => return,
-                    Err(x) => state = x,
+                    Err(x) => blocked_epoch = x,
                 }
                 continue;
             }
 
             // Park our thread until we are woken up by an unlock
             let addr = self as *const _ as usize;
-            let validate = || self.state.load(Relaxed);
+            let validate = || self.blocked_epoch.load(Relaxed) != NO_STARVERS_EPOCH;
             let before_sleep = || {};
             let timed_out = |_, _| {};
+            let park_token = ParkToken(epoch.get().get());
             match unsafe {
-                parking_lot_core::park(addr, validate, before_sleep, timed_out, STARVE_TOKEN, None)
+                parking_lot_core::park(addr, validate, before_sleep, timed_out, park_token, None)
             } {
-                ParkResult::Unparked(STARVE_HANDOFF) => return,
-                ParkResult::Unparked(_) => {
-                    if cfg!(debug_assertions) {
-                        panic!("unfairly unparking a starving thread")
+                ParkResult::Unparked(UnparkToken(wakeup_epoch)) => {
+                    debug_assert!(
+                        wakeup_epoch != NO_STARVERS_EPOCH,
+                        "unfairly unparking a starving thread"
+                    );
+                    if wakeup_epoch == epoch.get().get() {
+                        debug_assert_eq!(
+                            wakeup_epoch,
+                            self.blocked_epoch.load(Relaxed),
+                            "improperly set the blocked_epoch before handing off starvation \
+                             control"
+                        );
+                        return;
                     }
                 }
                 ParkResult::Invalid => {}
-                ParkResult::TimedOut => {
-                    debug_assert!(false);
-                    return;
-                }
+                ParkResult::TimedOut => debug_assert!(false),
             }
-            state = self.state.load(Relaxed);
+            blocked_epoch = self.blocked_epoch.load(Relaxed);
         }
     }
 
     #[cold]
     #[inline(never)]
-    fn wait_for_starvers_slow(&self) {
-        let mut state = self.state.load(Relaxed);
+    fn wait_for_starvers_slow<F: FnMut() -> Option<QuiesceEpoch>>(&self, mut should_upgrade: F) {
+        let mut blocked_epoch = self.blocked_epoch.load(Relaxed);
         loop {
-            if !state {
+            if blocked_epoch == NO_STARVERS_EPOCH {
                 return;
             }
 
             // Park our thread until we are woken up by an unlock
             let addr = self as *const _ as usize;
-            let validate = || self.state.load(Relaxed);
+            let validate = || self.blocked_epoch.load(Relaxed) != NO_STARVERS_EPOCH;
             let before_sleep = || {};
             let timed_out = |_, _| {};
+            if let Some(epoch) = should_upgrade() {
+                return self.starve_lock_slow(epoch);
+            }
             match unsafe {
-                parking_lot_core::park(addr, validate, before_sleep, timed_out, WAIT_TOKEN, None)
+                parking_lot_core::park(
+                    addr,
+                    validate,
+                    before_sleep,
+                    timed_out,
+                    ParkToken(NO_STARVERS_EPOCH),
+                    None,
+                )
             } {
-                ParkResult::Unparked(NO_STARVERS) => return,
-                ParkResult::Unparked(_) => {}
-                ParkResult::Invalid => {}
-                ParkResult::TimedOut => {
-                    debug_assert!(false);
+                ParkResult::Unparked(UnparkToken(NO_STARVERS_EPOCH)) => {
                     return;
                 }
+                ParkResult::Unparked(_) => {}
+                ParkResult::Invalid => {}
+                ParkResult::TimedOut => debug_assert!(false),
             }
-            state = self.state.load(Relaxed);
+            blocked_epoch = self.blocked_epoch.load(Relaxed);
         }
     }
 
     #[cold]
     #[inline(never)]
-    fn starve_unlock_slow(&self) {
+    fn starve_unlock_slow<F: FnOnce()>(&self, non_inlined_work: F) {
+        non_inlined_work();
+
         let addr = self as *const _ as usize;
-        let starvers = Cell::new(false);
-        let starvers = &starvers;
-        let filter = |token| {
-            if starvers.get() {
-                return FilterOp::Stop;
+        let starve_epoch = Cell::new(NO_STARVERS_EPOCH);
+        let starve_epoch = &starve_epoch;
+
+        // We don't know what thread we wish to unpark until we finish filtering. This means that
+        // threads will sometimes be unparked without the possibility of making progress.
+        let filter = |token: ParkToken| {
+            let epoch = starve_epoch.get();
+            if epoch == NO_STARVERS_EPOCH {
+                starve_epoch.set(token.0);
+                FilterOp::Unpark
+            } else if token.0 == NO_STARVERS_EPOCH {
+                FilterOp::Skip
+            } else if token.0 < epoch {
+                starve_epoch.set(token.0);
+                FilterOp::Unpark
+            } else {
+                FilterOp::Skip
             }
-            starvers.set(token == STARVE_TOKEN);
-            FilterOp::Unpark
         };
         let callback = |unpark_result: UnparkResult| {
-            if starvers.get() {
-                debug_assert!(unpark_result.unparked_threads > 0);
-                STARVE_HANDOFF
-            } else {
-                self.state.store(false, Relaxed);
-                NO_STARVERS
-            }
+            debug_assert_ne!(self.blocked_epoch.load(Relaxed), NO_STARVERS_EPOCH);
+            let epoch = starve_epoch.get();
+            self.blocked_epoch.store(epoch, Relaxed);
+            debug_assert!(epoch == NO_STARVERS_EPOCH || unpark_result.unparked_threads > 0);
+            UnparkToken(epoch)
         };
 
         let result = unsafe { parking_lot_core::unpark_filter(addr, filter, callback) };
+        if starve_epoch.get() != NO_STARVERS_EPOCH {
+            stats::starvation_handoff();
+        }
         stats::blocked_by_starvation(result.unparked_threads)
     }
 }
 
 #[derive(Copy, Clone)]
 enum ProgressImpl {
-    NotStarving(NonZeroU32),
+    NotStarving {
+        first_failed_epoch: Option<QuiesceEpoch>,
+        backoff:            NonZeroU32,
+    },
     Starving,
 }
 
@@ -169,8 +216,11 @@ pub struct Progress {
 impl Drop for Progress {
     fn drop(&mut self) {
         match self.inner.get() {
-            ProgressImpl::NotStarving(_) => {}
-            ProgressImpl::Starving => panic!("Progress dropped while Starving"),
+            ProgressImpl::NotStarving {
+                first_failed_epoch: None,
+                backoff,
+            } if backoff.get() == 0 => {}
+            _ => panic!("`Progress` dropped without having made progress"),
         }
     }
 }
@@ -179,28 +229,50 @@ impl Progress {
     #[inline]
     pub fn new() -> Self {
         Progress {
-            inner: Cell::new(ProgressImpl::NotStarving(NonZeroU32::new(1).unwrap())),
+            inner: Cell::new(ProgressImpl::NotStarving {
+                first_failed_epoch: None,
+                backoff:            NonZeroU32::new(1).unwrap(),
+            }),
         }
     }
 
+    /// Called when a thread has failed either the optimistic phase of concurrency, or the
+    /// pessimistic phase of concurrency.
     #[cold]
-    pub fn failed_to_progress(&self) {
+    pub fn failed_to_progress(&self, epoch: QuiesceEpoch) {
         match self.inner.get() {
-            ProgressImpl::NotStarving(count) => {
-                if count.get() <= SPIN_LIMIT {
-                    for _ in 0..1 << count.get() {
-                        atomic::spin_loop_hint();
+            ProgressImpl::NotStarving {
+                first_failed_epoch,
+                backoff,
+            } => {
+                let epoch = first_failed_epoch.unwrap_or(epoch);
+                if backoff.get() <= SPIN_LIMIT {
+                    let now = EPOCH_CLOCK.now().unwrap_or_else(|| abort!());
+                    if now.get().get() - epoch.get().get() >= MAX_ELAPSED_EPOCHS {
+                        self.inner.set(ProgressImpl::NotStarving {
+                            first_failed_epoch: Some(epoch),
+                            backoff:            unsafe {
+                                NonZeroU32::new_unchecked(SPIN_LIMIT + 1)
+                            },
+                        });
+                        thread::yield_now();
+                        return;
+                    } else {
+                        for _ in 0..1 << backoff.get() {
+                            atomic::spin_loop_hint();
+                        }
                     }
                 } else {
                     thread::yield_now();
                 }
 
-                if count.get() <= YIELD_LIMIT {
-                    self.inner.set(ProgressImpl::NotStarving(unsafe {
-                        NonZeroU32::new_unchecked(count.get() + 1)
-                    }));
+                if backoff.get() <= YIELD_LIMIT {
+                    self.inner.set(ProgressImpl::NotStarving {
+                        first_failed_epoch: Some(epoch),
+                        backoff:            unsafe { NonZeroU32::new_unchecked(backoff.get() + 1) },
+                    });
                 } else {
-                    STARVATION.starve_lock();
+                    STARVATION.starve_lock(epoch);
                     self.inner.set(ProgressImpl::Starving)
                 }
             }
@@ -208,23 +280,74 @@ impl Progress {
         };
     }
 
+    /// Called when a thread has finished the optimistic phase of concurrency, and is about to enter
+    /// a pessimistic phase where the threads progress will be published.
     #[inline]
     pub fn wait_for_starvers(&self) {
         match self.inner.get() {
-            ProgressImpl::NotStarving(_) => STARVATION.wait_for_starvers(),
+            ProgressImpl::NotStarving { .. } => {
+                STARVATION.wait_for_starvers(|| self.should_upgrade())
+            }
             ProgressImpl::Starving => {}
         };
     }
 
+    /// Called after progress has been made.
     #[inline]
     pub fn progressed(&self) {
         match self.inner.get() {
-            ProgressImpl::NotStarving(_) => {}
+            ProgressImpl::NotStarving { .. } => {}
             ProgressImpl::Starving => {
-                self.inner
-                    .set(ProgressImpl::NotStarving(NonZeroU32::new(1).unwrap()));
-                STARVATION.starve_unlock();
+                STARVATION.starve_unlock(|| {
+                    self.inner.set(ProgressImpl::NotStarving {
+                        first_failed_epoch: None,
+                        backoff:            NonZeroU32::new(1).unwrap(),
+                    })
+                });
             }
         };
+    }
+
+    #[inline]
+    fn should_upgrade(&self) -> Option<QuiesceEpoch> {
+        None
+        // match self.inner.get() {
+        //     ProgressImpl::NotStarving {
+        //         first_failed_epoch: Some(first_failed_epoch),
+        //         backoff,
+        //     } => {
+        //         if backoff.get() <= SPIN_LIMIT {
+        //             let now = EPOCH_CLOCK.now().unwrap_or_else(|| abort!());
+        //             if now.get().get() - first_failed_epoch.get().get() >= MAX_ELAPSED_EPOCHS {
+        //                 self.inner.set(ProgressImpl::NotStarving {
+        //                     first_failed_epoch: Some(first_failed_epoch),
+        //                     backoff:            unsafe {
+        //                         NonZeroU32::new_unchecked(SPIN_LIMIT + 1)
+        //                     },
+        //                 });
+        //                 thread::yield_now();
+        //                 return None;
+        //             } else {
+        //                 for _ in 0..1 << backoff.get() {
+        //                     atomic::spin_loop_hint();
+        //                 }
+        //             }
+        //         } else {
+        //             thread::yield_now();
+        //         }
+
+        //         if backoff.get() <= YIELD_LIMIT {
+        //             self.inner.set(ProgressImpl::NotStarving {
+        //                 first_failed_epoch: Some(first_failed_epoch),
+        //                 backoff:            unsafe { NonZeroU32::new_unchecked(backoff.get() + 1)
+        // },             });
+        //         } else {
+        //             epoch = Some(first_failed_epoch);
+        //             self.inner.set(ProgressImpl::Starving);
+        //         }
+        //     }
+        //     _ => {}
+        // };
+        // epoch
     }
 }

--- a/src/internal/starvation.rs
+++ b/src/internal/starvation.rs
@@ -38,7 +38,7 @@ use std::thread;
 static MAX_ELAPSED_EPOCHS: AtomicUsize = AtomicUsize::new(0);
 
 // TODO: tinker with this value
-const EPOCH_BUFFER_ROOM: usize = 16;
+const EPOCH_BUFFER_ROOM: usize = 2;
 
 #[inline]
 pub fn inc_thread_estimate() {

--- a/src/internal/thread.rs
+++ b/src/internal/thread.rs
@@ -4,7 +4,7 @@ use crate::{
         gc::{GlobalSynchList, OwnedSynch, ThreadGarbage},
         phoenix_tls::PhoenixTarget,
         read_log::ReadLog,
-        starvation::Progress,
+        starvation::{self, Progress},
         write_log::WriteLog,
     },
     read::ReadTx,
@@ -77,6 +77,7 @@ impl Thread {
 impl PhoenixTarget for Thread {
     fn subscribe(&mut self) {
         unsafe {
+            starvation::inc_thread_estimate();
             GlobalSynchList::instance().write().register(&self.synch);
         }
     }
@@ -96,6 +97,7 @@ impl PhoenixTarget for Thread {
             did_remove,
             "failed to find thread in the global thread list"
         );
+        starvation::dec_thread_estimate();
     }
 }
 

--- a/src/internal/thread.rs
+++ b/src/internal/thread.rs
@@ -281,7 +281,7 @@ impl<'tcell> Pin<'tcell> {
 
     #[inline]
     fn snooze_repin(&mut self) {
-        self.progress().failed_to_progress();
+        self.progress().failed_to_progress(self.pin_epoch());
         self.repin()
     }
 

--- a/src/internal/write_log.rs
+++ b/src/internal/write_log.rs
@@ -313,7 +313,7 @@ impl<'a, 'tcell> OccupiedEntry<'a, 'tcell> {
 
     pub fn tombstone_replace<T: 'static>(mut self, dest_tcell: &'tcell TCellErased, val: T) {
         let prev = self.entry.insert(self.data.word_len());
-        let entry = unsafe { self.data.word_index_unchecked_mut(prev) };
+        let mut entry = unsafe { self.data.word_index_unchecked_mut(prev) };
         debug_assert!(
             entry.tcell().is_some(),
             "unexpectedly tombstoning an already tombstoned write log entry"

--- a/src/internal/write_log.rs
+++ b/src/internal/write_log.rs
@@ -65,15 +65,6 @@ impl<'tcell> dyn WriteEntry + 'tcell {
     }
 
     #[inline]
-    pub fn deactivate(&mut self) {
-        debug_assert!(
-            self.tcell().is_some(),
-            "unexpectedly deactivating an inactive write log entry"
-        );
-        *self.tcell_mut() = None
-    }
-
-    #[inline]
     pub unsafe fn read<T>(&self) -> ManuallyDrop<T> {
         debug_assert!(
             mem::size_of_val(self) == mem::size_of::<WriteEntryImpl<'tcell, T>>(),
@@ -322,7 +313,12 @@ impl<'a, 'tcell> OccupiedEntry<'a, 'tcell> {
 
     pub fn tombstone_replace<T: 'static>(mut self, dest_tcell: &'tcell TCellErased, val: T) {
         let prev = self.entry.insert(self.data.word_len());
-        unsafe { self.data.word_index_unchecked_mut(prev).deactivate() };
+        let entry = unsafe { self.data.word_index_unchecked_mut(prev) };
+        debug_assert!(
+            entry.tcell().is_some(),
+            "unexpectedly tombstoning an already tombstoned write log entry"
+        );
+        *entry.tcell_mut() = None;
         self.data.push(WriteEntryImpl::new(dest_tcell, val));
     }
 }

--- a/src/rw.rs
+++ b/src/rw.rs
@@ -5,7 +5,9 @@
 //! Another subtle difference is a change to when the global clock is bumped. By doing it after
 //! TCells have had their value updated, but before releasing their locks, we can simplify reads.
 //! Reads don't have to read the per object epoch _before_ and after loading the value from shared
-//! memory. They only have to read the per object epoch after loading the value.
+//! memory. They only have to read the per object epoch after loading the value. Originally, it was
+//! thought this optimization was novel to swym, but it is documented in section 3.5.4 of Cunha's
+//! 2007 masters thesis: https://run.unl.pt/bitstream/10362/2312/1/Cunha_2007.pdf
 
 use crate::{
     internal::{

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -137,76 +137,7 @@ macro_rules! stats {
     };
 }
 
-stats! {
-    /// Number of conflicts per successful read transaction.
-    read_transaction_conflicts:         Size @ READ_TRANSACTION_CONFLICTS,
-
-    /// Number of eager (before commit) conflicts per successful write transaction.
-    write_transaction_eager_conflicts:  Size @ WRITE_TRANSACTION_EAGER_CONFLICTS,
-
-    /// Number of commit conflicts per successful write transaction.
-    write_transaction_commit_conflicts: Size @ WRITE_TRANSACTION_COMMIT_CONFLICTS,
-
-    /// Number of hardware conflicts per successful hardware transaction or software fallback.
-    ///
-    /// This is a less obvious metric. If a transaction completely fails and conflicts from the
-    /// start 10 times, each one attempting a hardware commit, then this will be recorded 10 times
-    /// with 10 different values.
-    htm_conflicts:                      Size @ HTM_CONFLICTS,
-
-    /// Number of `TCell`s in the read log at commit time.
-    read_size:                          Size @ READ_SIZE,
-
-    /// Number of cpu words in the write log at commit time. Each write is a minimum of 3 words.
-    write_word_size:                    Size @ WRITE_WORD_SIZE,
-
-    /// A bloom filter check.
-    bloom_check:                       Event @ BLOOM_CHECK,
-
-    /// A bloom filter collision.
-    bloom_collision:                   Event @ BLOOM_CHECK,
-
-    /// A bloom filter hit that required a full lookup to verify.
-    bloom_success_slow:                Event @ BLOOM_SUCCESS_SLOW,
-
-    /// A transactional read of data that exists in the write log. Considered slow.
-    read_after_write:                  Event @ READ_AFTER_WRITE,
-
-    /// A transactional overwrite of data that exists in the write log. Considered slow.
-    write_after_write:                 Event @ WRITE_AFTER_WRITE,
-
-    /// Number of transactional writes to data that has been logged as read from first. Considered
-    /// slowish.
-    ///
-    /// Writes after logged reads currently causes the commit algorithm to do more work.
-    write_after_logged_read:            Size @ WRITE_AFTER_LOGGED_READ,
-
-    /// Number of threads that were blocked by a starvation event.
-    blocked_by_starvation:              Size @ BLOCKED_BY_STARVATION,
-
-    /// Number of times a garbage collection cycle hit the maximum Backoff during quiescing.
-    should_park_gc:                     Size @ SHOULD_PARK_GC,
-
-    /// Number of threads awaiting retry ([`AWAIT_RETRY`](crate::tx::Status::AWAIT_RETRY)) woken up
-    /// per call to unpark.
-    unparked_size:                      Size @ UNPARKED_SIZE,
-
-    /// Number of threads awaiting retry ([`AWAIT_RETRY`](crate::tx::Status::AWAIT_RETRY)) that were
-    /// _not_ woken up per call to unpark.
-    not_unparked_size:                  Size @ NOT_UNPARKED_SIZE,
-
-    /// When a thread attempts to [`AWAIT_RETRY`](crate::tx::Status::AWAIT_RETRY), this is the
-    /// number of times it attempted a HTM park, and failed.
-    htm_park_conflicts:                 Size @ HTM_PARK_CONFLICTS,
-
-    /// When a thread attempts to [`AWAIT_RETRY`](crate::tx::Status::AWAIT_RETRY), but one of the
-    /// waited on `EpochLock`'s gets modified before being parked.
-    park_failure_size:                  Size @ PARK_FAILURE_SIZE,
-
-    /// Number of `EpochLock`s a parked (via [`AWAIT_RETRY`](crate::tx::Status::AWAIT_RETRY)) thread
-    /// can be woken up from.
-    parked_size:                        Size @ PARKED_SIZE,
-}
+include! {"./stats_list.rs"}
 
 impl Stats {
     /// Prints a summary of the stats object.

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -181,11 +181,8 @@ stats! {
     /// Writes after logged reads currently causes the commit algorithm to do more work.
     write_after_logged_read:            Size @ WRITE_AFTER_LOGGED_READ,
 
-    /// Number of times a read transaction hit the maximum Backoff.
-    should_park_read:                   Size @ SHOULD_PARK_READ,
-
-    /// Number of times a read/write transaction hit the maximum Backoff.
-    should_park_write:                  Size @ SHOULD_PARK_WRITE,
+    /// Number of threads that were blocked by a starvation event.
+    blocked_by_starvation:              Size @ BLOCKED_BY_STARVATION,
 
     /// Number of times a garbage collection cycle hit the maximum Backoff during quiescing.
     should_park_gc:                     Size @ SHOULD_PARK_GC,

--- a/src/stats_list.rs
+++ b/src/stats_list.rs
@@ -1,5 +1,3 @@
-
-
 stats! {
     /// Number of conflicts per successful read transaction.
     read_transaction_conflicts:         Size @ READ_TRANSACTION_CONFLICTS,
@@ -16,6 +14,9 @@ stats! {
     /// start 10 times, each one attempting a hardware commit, then this will be recorded 10 times
     /// with 10 different values.
     htm_conflicts:                      Size @ HTM_CONFLICTS,
+
+    /// Number of hardware transactional retries before an explicit hardware transaction abort.
+    htm_abort:                          Size @ HTM_ABORT,
 
     /// Number of `TCell`s in the read log at commit time.
     read_size:                          Size @ READ_SIZE,

--- a/src/stats_list.rs
+++ b/src/stats_list.rs
@@ -1,0 +1,75 @@
+
+
+stats! {
+    /// Number of conflicts per successful read transaction.
+    read_transaction_conflicts:         Size @ READ_TRANSACTION_CONFLICTS,
+
+    /// Number of eager (before commit) conflicts per successful write transaction.
+    write_transaction_eager_conflicts:  Size @ WRITE_TRANSACTION_EAGER_CONFLICTS,
+
+    /// Number of commit conflicts per successful write transaction.
+    write_transaction_commit_conflicts: Size @ WRITE_TRANSACTION_COMMIT_CONFLICTS,
+
+    /// Number of hardware conflicts per successful hardware transaction or software fallback.
+    ///
+    /// This is a less obvious metric. If a transaction completely fails and conflicts from the
+    /// start 10 times, each one attempting a hardware commit, then this will be recorded 10 times
+    /// with 10 different values.
+    htm_conflicts:                      Size @ HTM_CONFLICTS,
+
+    /// Number of `TCell`s in the read log at commit time.
+    read_size:                          Size @ READ_SIZE,
+
+    /// Number of cpu words in the write log at commit time. Each write is a minimum of 3 words.
+    write_word_size:                    Size @ WRITE_WORD_SIZE,
+
+    /// A bloom filter check.
+    bloom_check:                       Event @ BLOOM_CHECK,
+
+    /// A bloom filter collision.
+    bloom_collision:                   Event @ BLOOM_CHECK,
+
+    /// A bloom filter hit that required a full lookup to verify.
+    bloom_success_slow:                Event @ BLOOM_SUCCESS_SLOW,
+
+    /// A transactional read of data that exists in the write log. Considered slow.
+    read_after_write:                  Event @ READ_AFTER_WRITE,
+
+    /// A transactional overwrite of data that exists in the write log. Considered slow.
+    write_after_write:                 Event @ WRITE_AFTER_WRITE,
+
+    /// Number of transactional writes to data that has been logged as read from first. Considered
+    /// slowish.
+    ///
+    /// Writes after logged reads currently causes the commit algorithm to do more work.
+    write_after_logged_read:            Size @ WRITE_AFTER_LOGGED_READ,
+
+    /// Number of threads that were blocked by a starvation event.
+    blocked_by_starvation:              Size @ BLOCKED_BY_STARVATION,
+
+    /// Number of times the starvation control was handed off from thread to thread.
+    starvation_handoff:                Event @ STARVATION_HANDOFF,
+
+    /// Number of times a garbage collection cycle hit the maximum Backoff during quiescing.
+    should_park_gc:                     Size @ SHOULD_PARK_GC,
+
+    /// Number of threads awaiting retry ([`AWAIT_RETRY`](crate::tx::Status::AWAIT_RETRY)) woken up
+    /// per call to unpark.
+    unparked_size:                      Size @ UNPARKED_SIZE,
+
+    /// Number of threads awaiting retry ([`AWAIT_RETRY`](crate::tx::Status::AWAIT_RETRY)) that were
+    /// _not_ woken up per call to unpark.
+    not_unparked_size:                  Size @ NOT_UNPARKED_SIZE,
+
+    /// When a thread attempts to [`AWAIT_RETRY`](crate::tx::Status::AWAIT_RETRY), this is the
+    /// number of times it attempted a HTM park, and failed.
+    htm_park_conflicts:                 Size @ HTM_PARK_CONFLICTS,
+
+    /// When a thread attempts to [`AWAIT_RETRY`](crate::tx::Status::AWAIT_RETRY), but one of the
+    /// waited on `EpochLock`'s gets modified before being parked.
+    park_failure_size:                  Size @ PARK_FAILURE_SIZE,
+
+    /// Number of `EpochLock`s a parked (via [`AWAIT_RETRY`](crate::tx::Status::AWAIT_RETRY)) thread
+    /// can be woken up from.
+    parked_size:                        Size @ PARKED_SIZE,
+}

--- a/swym-rbtree/Cargo.toml
+++ b/swym-rbtree/Cargo.toml
@@ -16,6 +16,11 @@ stats = ["swym/stats"]
 swym = { path = "../" }
 
 [dev-dependencies]
+criterion = "0.2.11"
 crossbeam-utils = "0.6.5"
-jemallocator = "0.3.0"
+jemallocator = "0.3.2"
 rand = "0.6.5"
+
+[[bench]]
+name = "rbtree"
+harness = false

--- a/swym-rbtree/Cargo.toml
+++ b/swym-rbtree/Cargo.toml
@@ -16,7 +16,7 @@ stats = ["swym/stats"]
 swym = { path = "../" }
 
 [dev-dependencies]
-criterion = "0.2.11"
+criterion = { version = "0.2.11", default-features = false }
 crossbeam-utils = "0.6.5"
 jemallocator = "0.3.2"
 rand = "0.6.5"

--- a/swym-rbtree/benches/rbtree.rs
+++ b/swym-rbtree/benches/rbtree.rs
@@ -10,7 +10,7 @@ mod rbtree {
     use criterion::{BatchSize, Benchmark, Criterion, Throughput};
     use crossbeam_utils::thread;
     use rand::{seq::SliceRandom, thread_rng};
-    use std::rc::Rc;
+    use std::{rc::Rc, time::Duration};
     use swym_rbtree::RBTreeMap;
 
     const SAMPLE_SIZE: usize = 24;
@@ -18,6 +18,7 @@ mod rbtree {
     // Caps the total allocation size at a value where the allocators performance doesnt start to
     // crumble
     const NUM_ITERATIONS: u64 = COUNT as u64 * 300 / 100_000;
+    const WARMUP_TIME_NS: u64 = 1_000_000_000;
 
     fn random_data(count: usize) -> Rc<Vec<usize>> {
         let mut vec = Vec::new();
@@ -85,7 +86,7 @@ mod rbtree {
                 },
             )
             .sample_size(SAMPLE_SIZE)
-            .warm_up_time(std::time::Duration::from_nanos(1))
+            .warm_up_time(Duration::from_nanos(WARMUP_TIME_NS))
             .throughput(throughput)
         })
     }

--- a/swym-rbtree/benches/rbtree.rs
+++ b/swym-rbtree/benches/rbtree.rs
@@ -33,12 +33,6 @@ mod rbtree {
     fn spawn_chunked<F: Fn(usize) + Copy + Send + Sync>(data: &Vec<usize>, threads: usize, f: F) {
         let chunk = data.len() / threads;
 
-        assert_eq!(
-            chunk * threads,
-            data.len(),
-            "not an even amount of work for each thread"
-        );
-
         thread::scope(|scope| {
             for idx in 0..threads {
                 let chunk = &data[idx * chunk..(idx + 1) * chunk];

--- a/swym-rbtree/benches/rbtree.rs
+++ b/swym-rbtree/benches/rbtree.rs
@@ -1,219 +1,140 @@
-// based off of https://en.wikipedia.org/wiki/Red%E2%80%93black_tree
-// probly lots to optimize and cleanup
-
-#![feature(test)]
 #![deny(unused_must_use)]
 
-extern crate test;
+#[macro_use]
+extern crate criterion;
 
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 mod rbtree {
+    use criterion::{BatchSize, Benchmark, Criterion, Throughput};
     use crossbeam_utils::thread;
     use rand::{seq::SliceRandom, thread_rng};
+    use std::rc::Rc;
     use swym_rbtree::RBTreeMap;
-    use test::Bencher;
 
-    macro_rules! insert_bench {
-        ($name:ident, $count:expr, $threads:expr) => {
-            #[bench]
-            fn $name(bencher: &mut Bencher) {
-                const COUNT: usize = $count;
-                const THREADS: usize = $threads;
+    const SAMPLE_SIZE: usize = 24;
+    const COUNT: usize = 100_000;
+    // Caps the total allocation size at a value where the allocators performance doesnt start to
+    // crumble
+    const NUM_ITERATIONS: u64 = COUNT as u64 * 300 / 100_000;
 
-                let mut vec = Vec::new();
-                for x in 0..COUNT {
-                    vec.push(x);
-                }
-                let mut rng = thread_rng();
-                vec.shuffle(&mut rng);
-                let vec = &vec;
-
-                bencher.iter(move || {
-                    let _tree = RBTreeMap::new();
-                    let tree = &_tree;
-                    thread::scope(|scope| {
-                        for idx in 0..THREADS {
-                            scope.spawn(move |_| {
-                                for elem in
-                                    &vec[(idx * COUNT / THREADS)..((idx + 1) * COUNT / THREADS)]
-                                {
-                                    let elem = *elem;
-                                    tree.insert(elem, 0);
-                                }
-                            });
-                        }
-                    })
-                    .unwrap();
-                    std::mem::forget(_tree);
-                });
-                swym::stats::print_stats();
-            }
-        };
+    fn random_data(count: usize) -> Rc<Vec<usize>> {
+        let mut vec = Vec::new();
+        for x in 0..count {
+            vec.push(x);
+        }
+        let mut rng = thread_rng();
+        vec.shuffle(&mut rng);
+        Rc::new(vec)
     }
-    insert_bench! {insert_01_100000, 100000, 1}
-    insert_bench! {insert_02_100000, 100000, 2}
-    insert_bench! {insert_03_100000, 100000, 3}
-    insert_bench! {insert_04_100000, 100000, 4}
-    insert_bench! {insert_05_100000, 100000, 5}
-    insert_bench! {insert_06_100000, 100000, 6}
-    insert_bench! {insert_07_100000, 100000, 7}
-    insert_bench! {insert_08_100000, 100000, 8}
 
-    macro_rules! entry_bench {
-        ($name:ident, $count:expr, $threads:expr) => {
-            #[bench]
-            fn $name(bencher: &mut Bencher) {
-                const COUNT: usize = $count;
-                const THREADS: usize = $threads;
+    fn spawn_chunked<F: Fn(usize) + Copy + Send + Sync>(data: &Vec<usize>, threads: usize, f: F) {
+        let chunk = data.len() / threads;
 
-                let mut vec = Vec::new();
-                for x in 0..COUNT {
-                    vec.push(x);
-                }
-                let mut rng = thread_rng();
-                vec.shuffle(&mut rng);
-                let vec = &vec;
+        assert_eq!(
+            chunk * threads,
+            data.len(),
+            "not an even amount of work for each thread"
+        );
 
-                bencher.iter(move || {
-                    let _tree = RBTreeMap::new();
-                    let tree = &_tree;
-                    thread::scope(|scope| {
-                        for idx in 0..THREADS {
-                            scope.spawn(move |_| {
-                                for elem in
-                                    &vec[(idx * COUNT / THREADS)..((idx + 1) * COUNT / THREADS)]
-                                {
-                                    let elem = *elem;
-                                    tree.atomic(|mut tree| {
-                                        tree.entry(elem)?.or_insert(0)?;
-                                        Ok(())
-                                    })
-                                }
-                            });
-                        }
-                    })
-                    .unwrap();
-                });
-                swym::stats::print_stats();
-            }
-        };
-    }
-    entry_bench! {entry_01_100000, 100000, 1}
-    entry_bench! {entry_02_100000, 100000, 2}
-    entry_bench! {entry_03_100000, 100000, 3}
-    entry_bench! {entry_04_100000, 100000, 4}
-    entry_bench! {entry_05_100000, 100000, 5}
-    entry_bench! {entry_06_100000, 100000, 6}
-    entry_bench! {entry_07_100000, 100000, 7}
-    entry_bench! {entry_08_100000, 100000, 8}
-
-    macro_rules! get_bench {
-        ($name:ident, $count:expr, $threads:expr) => {
-            #[bench]
-            fn $name(bencher: &mut Bencher) {
-                const COUNT: usize = $count;
-                const THREADS: usize = $threads;
-
-                let mut vec = Vec::new();
-                for x in 0..COUNT {
-                    vec.push(x);
-                }
-                let mut rng = thread_rng();
-                vec.shuffle(&mut rng);
-                let vec = &vec;
-                let _tree = RBTreeMap::new();
-                let tree = &_tree;
-                thread::scope(|scope| {
-                    for idx in 0..8 {
-                        scope.spawn(move |_| {
-                            for elem in &vec[(idx * COUNT / 8)..((idx + 1) * COUNT / 8)] {
-                                tree.insert(*elem, 0);
-                            }
-                        });
+        thread::scope(|scope| {
+            for idx in 0..threads {
+                let chunk = &data[idx * chunk..(idx + 1) * chunk];
+                scope.spawn(move |_| {
+                    for elem in chunk {
+                        f(*elem)
                     }
-                })
-                .unwrap();
-
-                bencher.iter(move || {
-                    thread::scope(|scope| {
-                        for idx in 0..THREADS {
-                            scope.spawn(move |_| {
-                                for elem in
-                                    &vec[(idx * COUNT / THREADS)..((idx + 1) * COUNT / THREADS)]
-                                {
-                                    tree.get(elem).unwrap();
-                                }
-                            });
-                        }
-                    })
-                    .unwrap();
                 });
-                swym::stats::print_stats();
             }
-        };
+        })
+        .unwrap();
     }
-    get_bench! {get_01_100000, 100000, 1}
-    get_bench! {get_02_100000, 100000, 2}
-    get_bench! {get_03_100000, 100000, 3}
-    get_bench! {get_04_100000, 100000, 4}
-    get_bench! {get_05_100000, 100000, 5}
-    get_bench! {get_06_100000, 100000, 6}
-    get_bench! {get_07_100000, 100000, 7}
-    get_bench! {get_08_100000, 100000, 8}
 
-    macro_rules! contains_key_bench {
-        ($name:ident, $count:expr, $threads:expr) => {
-            #[bench]
-            fn $name(bencher: &mut Bencher) {
-                const COUNT: usize = $count;
-                const THREADS: usize = $threads;
+    fn thread_benches<S, F, O>(
+        name: &'static str,
+        data: Rc<Vec<usize>>,
+        setup: S,
+        f: F,
+    ) -> impl Iterator<Item = Benchmark>
+    where
+        S: Fn() -> O + Copy + 'static,
+        F: Fn(&O, usize) + Copy + Send + Sync + 'static,
+        O: Sync,
+    {
+        (1..=8).map(move |threads| {
+            let throughput = Throughput::Elements(data.len() as _);
+            let data = data.clone();
+            Benchmark::new(
+                format!(
+                    "{name}_{threads:002}_{count}",
+                    name = name,
+                    threads = threads,
+                    count = data.len()
+                ),
+                move |bencher| {
+                    let data = &data;
+                    bencher.iter_batched(
+                        setup,
+                        move |o| {
+                            spawn_chunked(data, threads, |elem| f(&o, elem));
+                            o
+                        },
+                        BatchSize::NumIterations(NUM_ITERATIONS),
+                    );
+                },
+            )
+            .sample_size(SAMPLE_SIZE)
+            .warm_up_time(std::time::Duration::from_nanos(1))
+            .throughput(throughput)
+        })
+    }
 
-                let mut vec = Vec::new();
-                for x in 0..COUNT {
-                    vec.push(x);
-                }
-                let mut rng = thread_rng();
-                vec.shuffle(&mut rng);
-                let vec = &vec;
-                let _tree = RBTreeMap::new();
-                let tree = &_tree;
-                thread::scope(|scope| {
-                    for idx in 0..8 {
-                        scope.spawn(move |_| {
-                            for elem in &vec[(idx * COUNT / 8)..((idx + 1) * COUNT / 8)] {
-                                tree.insert(*elem, 0);
-                            }
-                        });
-                    }
+    pub fn benches(c: &mut Criterion) {
+        let data = random_data(COUNT);
+        let const_tree = Box::new(RBTreeMap::new());
+        spawn_chunked(&data, 8, |elem| drop(const_tree.insert(elem, 0)));
+        let const_tree = unsafe { &*Box::into_raw(const_tree) };
+
+        let benches = thread_benches(
+            "insert",
+            data.clone(),
+            || RBTreeMap::new(),
+            |tree, elem| drop(tree.insert(elem, 0)),
+        )
+        .chain(thread_benches(
+            "entry",
+            data.clone(),
+            || RBTreeMap::new(),
+            |tree, elem| {
+                tree.atomic(move |mut tree| {
+                    tree.entry(elem)?.or_insert(0)?;
+                    Ok(())
                 })
-                .unwrap();
-
-                bencher.iter(move || {
-                    thread::scope(|scope| {
-                        for idx in 0..THREADS {
-                            scope.spawn(move |_| {
-                                for elem in
-                                    &vec[(idx * COUNT / THREADS)..((idx + 1) * COUNT / THREADS)]
-                                {
-                                    assert!(tree.contains_key(elem));
-                                }
-                            });
-                        }
-                    })
-                    .unwrap();
-                });
-                swym::stats::print_stats();
-            }
-        };
+            },
+        ))
+        .chain(thread_benches(
+            "get",
+            data.clone(),
+            || (),
+            move |(), elem| {
+                const_tree.get(&elem).unwrap();
+            },
+        ))
+        .chain(thread_benches(
+            "contains_key",
+            data,
+            || (),
+            move |(), elem| {
+                assert!(const_tree.contains_key(&elem));
+            },
+        ));
+        for bench in benches {
+            c.bench("rbtree", bench);
+        }
+        swym::stats::print_stats();
     }
-    contains_key_bench! {contains_key_01_100000, 100000, 1}
-    contains_key_bench! {contains_key_02_100000, 100000, 2}
-    contains_key_bench! {contains_key_03_100000, 100000, 3}
-    contains_key_bench! {contains_key_04_100000, 100000, 4}
-    contains_key_bench! {contains_key_05_100000, 100000, 5}
-    contains_key_bench! {contains_key_06_100000, 100000, 6}
-    contains_key_bench! {contains_key_07_100000, 100000, 7}
-    contains_key_bench! {contains_key_08_100000, 100000, 8}
 }
+
+criterion::criterion_group!(benches, rbtree::benches);
+criterion::criterion_main!(benches);

--- a/tests/starvation.rs
+++ b/tests/starvation.rs
@@ -6,7 +6,8 @@ mod starvation {
 
     #[test]
     fn large_tx() {
-        const TX_SIZE: usize = 1_000;
+        const CONTENDED_IDX: usize = 0;
+        const TX_SIZE: usize = 50_000;
         let data = unsafe { &mut *Box::into_raw(Box::new(Vec::new())) };
         for _ in 0..TX_SIZE {
             data.push(TCell::new(0));
@@ -19,14 +20,15 @@ mod starvation {
             std::process::abort();
         });
 
-        // small thread
+        // thread that starves other threads
         std::thread::spawn(move || loop {
             thread_key::get().rw(|tx| {
-                data[0].set(tx, 0)?;
+                data[CONTENDED_IDX].set(tx, 0)?;
                 Ok(())
             })
         });
 
+        // rw
         thread::scope(|s| {
             // starving thread
             s.spawn(|_| {
@@ -39,5 +41,54 @@ mod starvation {
             });
         })
         .unwrap();
+        swym::stats::print_stats();
+
+        // read
+        thread::scope(|s| {
+            // starving thread
+            s.spawn(|_| {
+                thread_key::get().read(|tx| {
+                    // read the contended variable last
+                    for i in (0..TX_SIZE).rev() {
+                        drop(data[i].get(tx, Default::default())?);
+                    }
+                    Ok(())
+                })
+            });
+        })
+        .unwrap();
+        swym::stats::print_stats();
+
+        // check for gc deadlock
+        let string = TCell::new("blah blah".to_owned());
+        let other = TCell::new(0);
+        thread::scope(|s| {
+            s.spawn(|_| {
+                thread_key::get().rw(|tx| {
+                    // block gc
+                    std::thread::sleep(std::time::Duration::from_millis(1_000));
+                    // causes a park before commit
+                    other.set(tx, 0)?;
+                    Ok(())
+                })
+            });
+            // starving thread
+            s.spawn(|_| {
+                // run enough times that gc happens
+                for _ in 0..128 {
+                    thread_key::get().rw(|tx| {
+                        // doom the transaction
+                        drop(data[CONTENDED_IDX].get(tx, Default::default())?);
+                        std::thread::sleep(std::time::Duration::from_millis(1));
+
+                        // create work for the gc
+                        string.set(tx, "blah".to_owned())?;
+                        Ok(())
+                    })
+                }
+            });
+        })
+        .unwrap();
+        swym::stats::print_stats();
     }
 }

--- a/tests/starvation.rs
+++ b/tests/starvation.rs
@@ -1,0 +1,43 @@
+#![feature(test)]
+
+mod starvation {
+    use crossbeam_utils::thread;
+    use swym::{tcell::TCell, thread_key};
+
+    #[test]
+    fn large_tx() {
+        const TX_SIZE: usize = 1_000;
+        let data = unsafe { &mut *Box::into_raw(Box::new(Vec::new())) };
+        for _ in 0..TX_SIZE {
+            data.push(TCell::new(0));
+        }
+        let data = &*data;
+
+        // abort if test lasts too long (failure)
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_secs(10));
+            std::process::abort();
+        });
+
+        // small thread
+        std::thread::spawn(move || loop {
+            thread_key::get().rw(|tx| {
+                data[0].set(tx, 0)?;
+                Ok(())
+            })
+        });
+
+        thread::scope(|s| {
+            // starving thread
+            s.spawn(|_| {
+                thread_key::get().rw(|tx| {
+                    for i in 0..TX_SIZE {
+                        data[i].set(tx, 0)?;
+                    }
+                    Ok(())
+                })
+            });
+        })
+        .unwrap();
+    }
+}


### PR DESCRIPTION
`mem::forget` in the rbtree insertion benchmarks would occasionally cause large spikes in the benchmarks due to the testing harness deciding to run the benchmark 900 times instead of 300. This created a lot pressure on the allocator, resulting in slowness unrelated to swym. `criterion` allows exclusion of the destructors from the benchmark timings, as well as the batch running destructors.

`swym` now prevents transactions from starving. This means that all transactions will eventually commit (unless of course there's an infinite loop, deadlock or other user bug).

One less footgun when using swym!