### PR TITLE
rtm based on stdarch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/mtak-/swym"
 documentation = "https://docs.rs/swym"
 
 [package.metadata.docs.rs]
-features = ["rtm"]
+features = ["nightly"]
 default-target = "x86_64-unknown-linux-gnu"
 rustc-args = ["-Ctarget-feature=+rtm"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ nightly = [
     "lock_api/nightly",
     "parking_lot/nightly",
     "parking_lot_core/nightly",
+    "swym-htm/nightly",
 ]
-rtm = ["swym-htm/rtm"]
 stats = []
 
 [dependencies]

--- a/ci/htm.sh
+++ b/ci/htm.sh
@@ -4,6 +4,8 @@ set -ex
 
 cd "$(dirname "$0")"/../swym-htm
 
+# the "+rtm" feature has to be set because the travis linux vm incorrectly thinks it doesn't support
+# rtm
 export RUSTFLAGS="-D warnings -Ctarget-feature=+rtm"
 
 cargo check --no-default-features --benches --bins --examples --tests

--- a/ci/htm.sh
+++ b/ci/htm.sh
@@ -4,11 +4,11 @@ set -ex
 
 cd "$(dirname "$0")"/../swym-htm
 
-export RUSTFLAGS="-D warnings"
+export RUSTFLAGS="-D warnings -Ctarget-feature=+rtm"
 
-cargo check --no-default-features
+cargo check --no-default-features --benches --bins --examples --tests
 cargo check --benches --bins --examples --tests
-cargo check --features rtm --benches --bins --examples --tests
+cargo check --features nightly --benches --bins --examples --tests
 cargo check --features htm --benches --bins --examples --tests
 ./x.py test
 ./x.py test --release -- --nocapture

--- a/ci/rbtree.sh
+++ b/ci/rbtree.sh
@@ -5,14 +5,8 @@ set -ex
 cd "$(dirname "$0")"/../swym-rbtree
 
 export RUSTFLAGS="-D warnings -Ctarget-cpu=native -Ctarget-feature=+rtm"
-export RTM="rtm"
 export ASAN_FLAG="-Z sanitizer=address"
 export ASAN_OPTIONS="detect_odr_violation=0 detect_leaks=0"
-
-if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    # no rtm support
-    export RTM=""
-fi
 
 # cheeck all combinations of features
 cargo check --no-default-features --benches --bins --examples --tests

--- a/ci/rbtree.sh
+++ b/ci/rbtree.sh
@@ -4,31 +4,39 @@ set -ex
 
 cd "$(dirname "$0")"/../swym-rbtree
 
-export RUSTFLAGS="-D warnings -Ctarget-cpu=native -Ctarget-feature=+rtm"
+# the "+rtm" feature has to be set because the travis linux vm incorrectly thinks it doesn't support
+# rtm
+export RTM="-Ctarget-feature=+rtm"
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    # no rtm support
+    export RTM=""
+fi
+
+export RUSTFLAGS="-D warnings -Ctarget-cpu=native ${RTM}"
 export ASAN_FLAG="-Z sanitizer=address"
 export ASAN_OPTIONS="detect_odr_violation=0 detect_leaks=0"
 
 # cheeck all combinations of features
 cargo check --no-default-features --benches --bins --examples --tests
 cargo check --benches --bins --examples --tests
-cargo check --features "$RTM" --benches --bins --examples --tests
+cargo check --benches --bins --examples --tests
 cargo check --features stats --benches --bins --examples --tests
 cargo check --features nightly --benches --bins --examples --tests
-cargo check --features stats,$RTM --benches --bins --examples --tests
-cargo check --features nightly,$RTM --benches --bins --examples --tests
+cargo check --features stats --benches --bins --examples --tests
+cargo check --features nightly --benches --bins --examples --tests
 cargo check --features stats,nightly --benches --bins --examples --tests
-cargo check --features nightly,stats,$RTM --benches --bins --examples --tests
+cargo check --features nightly,stats --benches --bins --examples --tests
 # debug-alloc shouldn't change anything
-cargo check --features debug-alloc,nightly,stats,$RTM --benches --bins --examples --tests
+cargo check --features debug-alloc,nightly,stats --benches --bins --examples --tests
 
 # run tests
 ./x.py test
-RUST_TEST_THREADS=1 cargo test --features stats,nightly,$RTM --lib --tests
+RUST_TEST_THREADS=1 cargo test --features stats,nightly --lib --tests
 
 # TODO: address sanitizer doesn't work with criterion?
 # RUSTFLAGS="${RUSTFLAGS} ${ASAN_FLAG}"
 RUST_TEST_THREADS=1 \
-    time cargo test --features debug-alloc,stats,$RTM
+    time cargo test --features debug-alloc,stats
 
 # benchmarks
-./x.py bench --features nightly,$RTM
+./x.py bench --features nightly

--- a/ci/swym.sh
+++ b/ci/swym.sh
@@ -5,14 +5,8 @@ set -ex
 cd "$(dirname "$0")"/..
 
 export RUSTFLAGS="-D warnings -Ctarget-cpu=native -Ctarget-feature=+rtm"
-export RTM="rtm"
 export ASAN_FLAG="-Z sanitizer=address"
 export ASAN_OPTIONS="detect_odr_violation=0 detect_leaks=0"
-
-if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    # no rtm support
-    export RTM=""
-fi
 
 # cheeck all combinations of features
 cargo check --no-default-features --benches --bins --examples --tests
@@ -47,8 +41,4 @@ time cargo run \
     --example tlock
 
 # benchmarks
-if [[ -z $RTM ]]; then
-    ./x.py bench --features nightly
-else
-    ./x.py bench --features rtm,nightly
-fi
+./x.py bench --features nightly

--- a/ci/swym.sh
+++ b/ci/swym.sh
@@ -4,40 +4,48 @@ set -ex
 
 cd "$(dirname "$0")"/..
 
-export RUSTFLAGS="-D warnings -Ctarget-cpu=native -Ctarget-feature=+rtm"
+# the "+rtm" feature has to be set because the travis linux vm incorrectly thinks it doesn't support
+# rtm
+export RTM="-Ctarget-feature=+rtm"
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    # no rtm support
+    export RTM=""
+fi
+
+export RUSTFLAGS="-D warnings -Ctarget-cpu=native ${RTM}"
 export ASAN_FLAG="-Z sanitizer=address"
 export ASAN_OPTIONS="detect_odr_violation=0 detect_leaks=0"
 
 # cheeck all combinations of features
 cargo check --no-default-features --benches --bins --examples --tests
 cargo check --benches --bins --examples --tests
-cargo check --features "$RTM" --benches --bins --examples --tests
+cargo check --benches --bins --examples --tests
 cargo check --features stats --benches --bins --examples --tests
 cargo check --features nightly --benches --bins --examples --tests
-cargo check --features stats,$RTM --benches --bins --examples --tests
-cargo check --features nightly,$RTM --benches --bins --examples --tests
+cargo check --features stats --benches --bins --examples --tests
+cargo check --features nightly --benches --bins --examples --tests
 cargo check --features stats,nightly --benches --bins --examples --tests
-cargo check --features nightly,stats,$RTM --benches --bins --examples --tests
+cargo check --features nightly,stats --benches --bins --examples --tests
 # debug-alloc shouldn't change anything
-cargo check --features debug-alloc,nightly,stats,$RTM --benches --bins --examples --tests
+cargo check --features debug-alloc,nightly,stats --benches --bins --examples --tests
 
 # run tests
 ./x.py test
-RUST_TEST_THREADS=1 cargo test --features stats,nightly,$RTM --lib --tests
+RUST_TEST_THREADS=1 cargo test --features stats,nightly --lib --tests
 
 # examples
 RUSTFLAGS="${RUSTFLAGS} ${ASAN_FLAG}" \
     time cargo run \
         --release \
-        --features debug-alloc,stats,$RTM \
+        --features debug-alloc,stats \
         --example stack
 
 time cargo run \
-    --features stats,$RTM \
+    --features stats \
     --example dining_philosophers
 
 time cargo run \
-    --features stats,$RTM \
+    --features stats \
     --example tlock
 
 # benchmarks

--- a/swym-htm/Cargo.toml
+++ b/swym-htm/Cargo.toml
@@ -11,14 +11,15 @@ repository = "https://github.com/mtak-/swym"
 homepage = "https://github.com/mtak-/swym"
 
 [package.metadata.docs.rs]
-features = ["rtm"]
+features = ["nightly"]
 default-target = "x86_64-unknown-linux-gnu"
 rustc-args = ["-Ctarget-feature=+rtm"]
 
 [features]
-default = []
+default = ["nightly"]
 htm = []
-rtm = []
+nightly = []
 
 [dependencies]
-cfg-if = "0.1.7"
+cfg-if = "0.1.9"
+nudge = "0.2.1"

--- a/swym-htm/src/lib.rs
+++ b/swym-htm/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![cfg_attr(feature = "htm", feature(link_llvm_intrinsics))]
 #![cfg_attr(feature = "nightly", feature(stdsimd))]
+#![cfg_attr(feature = "nightly", feature(rtm_target_feature))]
 #![feature(test)]
 #![warn(missing_docs)]
 

--- a/swym-htm/src/lib.rs
+++ b/swym-htm/src/lib.rs
@@ -1,8 +1,7 @@
 //! Hardware transactional memory primitives
 
-#![cfg_attr(not(test), no_std)]
-#![feature(core_intrinsics)]
-#![feature(link_llvm_intrinsics)]
+#![cfg_attr(feature = "htm", feature(link_llvm_intrinsics))]
+#![cfg_attr(feature = "nightly", feature(stdsimd))]
 #![feature(test)]
 #![warn(missing_docs)]
 
@@ -13,7 +12,7 @@ cfg_if::cfg_if! {
     if #[cfg(all(target_arch = "powerpc64", feature = "htm"))] {
         pub mod powerpc64;
         use powerpc64 as back;
-    } else if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "rtm"))] {
+    } else if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "nightly"))] {
         pub mod x86_64;
         use x86_64 as back;
     } else {
@@ -29,16 +28,10 @@ use core::{
     sync::atomic::AtomicUsize,
 };
 
-/// Returns true if the platform may support hardware transactional memory.
+/// Returns true if the platform supports hardware transactional memory.
 #[inline]
-pub const fn htm_supported() -> bool {
+pub fn htm_supported() -> bool {
     back::htm_supported()
-}
-
-/// Returns true if the platform definitely supports hardware transactional memory.
-#[inline]
-pub fn htm_supported_runtime() -> bool {
-    back::htm_supported_runtime()
 }
 
 /// Attempts to begin a hardware transaction.
@@ -171,8 +164,13 @@ impl HardwareTx {
     where
         F: FnMut(BeginCode) -> Result<(), E>,
     {
+        debug_assert!(
+            htm_supported(),
+            "Hardware transactional memory is not supported on this target. Check `htm_supported` \
+             before attempting a transaction"
+        );
         let b = begin();
-        if core::intrinsics::likely(b.is_started()) {
+        if nudge::likely(b.is_started()) {
             return Ok(HardwareTx {
                 _private: PhantomData,
             });
@@ -497,19 +495,10 @@ fn capacity_check() {
     );
 }
 
-// fails in virtualization
-#[ignore]
 #[test]
 fn supported() {
-    let compile = htm_supported();
-    let runtime = htm_supported_runtime();
-    if compile {
-        assert!(runtime);
-    }
-
-    println!("");
-    println!("compile time support check: {}", compile);
-    println!("     runtime support check: {}", runtime);
+    let supported = htm_supported();
+    println!("runtime support check: {}", supported);
 }
 
 #[bench]

--- a/swym-htm/src/powerpc64.rs
+++ b/swym-htm/src/powerpc64.rs
@@ -239,9 +239,3 @@ pub(super) const fn htm_supported() -> bool {
     // TODO:
     false
 }
-
-#[inline]
-pub(super) const fn htm_supported_runtime() -> bool {
-    // TODO:
-    false
-}

--- a/swym-htm/src/unsupported.rs
+++ b/swym-htm/src/unsupported.rs
@@ -74,8 +74,3 @@ pub(super) unsafe fn end() {
 pub(super) const fn htm_supported() -> bool {
     false
 }
-
-#[inline]
-pub(super) const fn htm_supported_runtime() -> bool {
-    false
-}

--- a/swym-htm/src/x86_64.rs
+++ b/swym-htm/src/x86_64.rs
@@ -59,22 +59,26 @@ impl TestCode {
     }
 }
 
+#[target_feature(enable = "rtm")]
 #[inline]
 pub(super) unsafe fn begin() -> BeginCode {
     BeginCode(_xbegin())
 }
 
-#[inline(always)]
+#[target_feature(enable = "rtm")]
+#[inline]
 pub(super) unsafe fn abort() -> ! {
     _xabort(0);
     core::hint::unreachable_unchecked();
 }
 
+#[target_feature(enable = "rtm")]
 #[inline]
 pub(super) unsafe fn test() -> TestCode {
     TestCode(_xtest())
 }
 
+#[target_feature(enable = "rtm")]
 #[inline]
 pub(super) unsafe fn end() {
     _xend()

--- a/swym-htm/src/x86_64.rs
+++ b/swym-htm/src/x86_64.rs
@@ -1,107 +1,20 @@
-//! Raw x86_64 Restricted Transactional Memory primitives.
-//!
-//! To enable this module use the `--features rtm` switch.
-//!
-//! A compatible CPU is required. Additionally these `RUSTFLAGS` may be necessary.
-//!
-//! ```sh
-//! RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=+rtm"
-//! ```
-//!
-//! The [Intel programming considerations](https://software.intel.com/en-us/cpp-compiler-developer-guide-and-reference-intel-transactional-synchronization-extensions-intel-tsx-programming-considerations)
-//! are a recommended read for using this module.
+//! x86_64 hardware intrinsics
 
-mod intrinsics {
-    extern "C" {
-        #[link_name = "llvm.x86.xbegin"]
-        pub fn xbegin() -> i32;
-
-        #[link_name = "llvm.x86.xend"]
-        pub fn xend() -> ();
-
-        #[link_name = "llvm.x86.xabort"]
-        pub fn xabort(a: i8) -> ();
-
-        #[link_name = "llvm.x86.xtest"]
-        pub fn xtest() -> i32;
+cfg_if::cfg_if! {
+    if #[cfg(target_arch = "x86")] {
+        use core::arch::x86 as x86;
+    } else if #[cfg(target_arch = "x86_64")] {
+        use core::arch::x86_64 as x86;
     }
 }
-
-/// Abort codes must be immediates.
-///
-/// There's no way to represent immediates in rust at the moment, but this trait works in practice.
-pub trait XAbortConst {
-    /// The code with which to abort.
-    const CODE: i8;
-}
-
-/// Specifies the start of a restricted transactional memory (RTM) code region and returns a value
-/// indicating status.
-///
-/// See the [Intel documentation](https://software.intel.com/en-us/cpp-compiler-developer-guide-and-reference-xbegin).
-#[inline]
-pub unsafe fn xbegin() -> i32 {
-    intrinsics::xbegin()
-}
-
-/// Specifies the end of a restricted transactional memory (RTM) code region.
-///
-/// See the [Intel documentation](https://software.intel.com/en-us/cpp-compiler-developer-guide-and-reference-xend).
-#[inline]
-pub unsafe fn xend() {
-    intrinsics::xend()
-}
-
-/// Forces a restricted transactional memory (RTM) region to abort.
-///
-/// See the [Intel documentation](https://software.intel.com/en-us/cpp-compiler-developer-guide-and-reference-xabort).
-#[inline(always)]
-pub unsafe fn xabort<T: XAbortConst>() -> ! {
-    intrinsics::xabort(T::CODE);
-    core::hint::unreachable_unchecked()
-}
-
-/// Queries whether the processor is executing in a transactional region identified by restricted
-/// transactional memory (RTM) or hardware lock elision (HLE).
-///
-/// See the [Intel documentation](https://software.intel.com/en-us/cpp-compiler-developer-guide-and-reference-xtest).
-#[inline]
-pub unsafe fn xtest() -> i32 {
-    intrinsics::xtest()
-}
-
-/// Transaction successfully started.
-pub const _XBEGIN_STARTED: i32 = !0 as i32;
-
-/// Transaction explicitly aborted with xabort. The parameter passed to xabort is available with
-/// _XABORT_CODE(status).
-pub const _XABORT_EXPLICIT: i32 = 1i32 << 0;
-
-/// Transaction retry is possible.
-pub const _XABORT_RETRY: i32 = 1i32 << 1;
-
-/// Transaction abort due to a memory conflict with another thread.
-pub const _XABORT_CONFLICT: i32 = 1i32 << 2;
-
-/// Transaction abort due to the transaction using too much memory.
-pub const _XABORT_CAPACITY: i32 = 1i32 << 3;
-
-/// Transaction abort due to a debug trap.
-pub const _XABORT_DEBUG: i32 = 1i32 << 4;
-
-/// Transaction abort in a inner nested transaction.
-pub const _XABORT_NESTED: i32 = 1i32 << 5;
-
-/// Retrieves the parameter passed to xabort when status has the `_XABORT_EXPLICIT` flag set.
-#[allow(non_snake_case)]
-#[inline(always)]
-pub const fn _XABORT_CODE(status: i32) -> i32 {
-    ((status as u32 >> 24) & 0xFFu32) as i32
-}
+use x86::{
+    _xabort, _xbegin, _xend, _xtest, _XABORT_CONFLICT, _XABORT_EXPLICIT, _XABORT_RETRY,
+    _XBEGIN_STARTED,
+};
 
 #[repr(transparent)]
 #[derive(PartialEq, Eq, Ord, PartialOrd, Copy, Clone, Debug, Hash)]
-pub(super) struct BeginCode(i32);
+pub(super) struct BeginCode(u32);
 
 impl BeginCode {
     #[inline]
@@ -132,7 +45,7 @@ impl BeginCode {
 
 #[repr(transparent)]
 #[derive(PartialEq, Eq, Ord, PartialOrd, Copy, Clone, Debug, Hash)]
-pub(super) struct TestCode(i32);
+pub(super) struct TestCode(u8);
 
 impl TestCode {
     #[inline]
@@ -148,34 +61,26 @@ impl TestCode {
 
 #[inline]
 pub(super) unsafe fn begin() -> BeginCode {
-    BeginCode(xbegin())
+    BeginCode(_xbegin())
 }
 
 #[inline(always)]
 pub(super) unsafe fn abort() -> ! {
-    struct Code;
-    impl XAbortConst for Code {
-        const CODE: i8 = 0;
-    }
-    xabort::<Code>();
+    _xabort(0);
+    core::hint::unreachable_unchecked();
 }
 
 #[inline]
 pub(super) unsafe fn test() -> TestCode {
-    TestCode(xtest())
+    TestCode(_xtest())
 }
 
 #[inline]
 pub(super) unsafe fn end() {
-    xend()
+    _xend()
 }
 
 #[inline]
-pub(super) const fn htm_supported() -> bool {
-    true
-}
-
-#[inline]
-pub(super) fn htm_supported_runtime() -> bool {
-    unsafe { core::arch::x86_64::__cpuid_count(0x7, 0x0).ebx & (1 << 11) != 0 }
+pub(super) fn htm_supported() -> bool {
+    is_x86_feature_detected!("rtm")
 }

--- a/swym-htm/x.py
+++ b/swym-htm/x.py
@@ -4,11 +4,11 @@ import os
 import sys
 
 if sys.argv[1] == 'test' or sys.argv[1] == 'doc':
-    prefix = 'RUST_TEST_THREADS=1 RUSTFLAGS="$RUSTFLAGS -Ctarget-feature=+rtm -Ctarget-cpu=native"'
-    suffix = '--features rtm'
+    prefix = 'RUST_TEST_THREADS=1'
+    suffix = ''
 elif sys.argv[1] == 'bench':
-    prefix = 'RUSTFLAGS="$RUSTFLAGS -Ctarget-feature=+rtm -Ctarget-cpu=native"'
-    suffix = '--features rtm'
+    prefix = ''
+    suffix = ''
 else:
     prefix = ''
     suffix = ''

--- a/swym-rbtree/Cargo.toml
+++ b/swym-rbtree/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 debug-alloc = ["jemallocator/debug"]
 default = []
 nightly = ["swym/nightly"]
-rtm = ["swym/rtm"]
 stats = ["swym/stats"]
 
 [dependencies]

--- a/swym-rbtree/x.py
+++ b/swym-rbtree/x.py
@@ -7,7 +7,7 @@ if sys.argv[1] == 'test':
     prefix = "RUST_TEST_THREADS=1"
     suffix = '--features stats'
 elif sys.argv[1] == 'bench':
-    prefix = 'RUSTFLAGS="$RUSTFLAGS -Ctarget-cpu=native -Ctarget-feature=+rtm"'
+    prefix = 'RUSTFLAGS="$RUSTFLAGS -Ctarget-cpu=native"'
     suffix = ''
 else:
     prefix = ''

--- a/x.py
+++ b/x.py
@@ -4,10 +4,10 @@ import os
 import sys
 
 if sys.argv[1] == 'test':
-    prefix = 'RUST_TEST_THREADS=1 RUSTFLAGS="$RUSTFLAGS -Ctarget-feature=+rtm"'
+    prefix = 'RUST_TEST_THREADS=1 RUSTFLAGS="$RUSTFLAGS"'
     suffix = '--features debug-alloc,nightly,stats'
 elif sys.argv[1] == 'bench':
-    prefix = 'RUSTFLAGS="$RUSTFLAGS -Ctarget-cpu=native -Ctarget-feature=+rtm"'
+    prefix = 'RUSTFLAGS="$RUSTFLAGS -Ctarget-cpu=native"'
     suffix = ''
 else:
     prefix = ''


### PR DESCRIPTION
Today, `stdarch` was bumped in `rust-lang/rust` to include the `rtm` intrinsics. This PR implements the x86 `swym-htm` backend using those intrinsics.